### PR TITLE
Inital idt setup

### DIFF
--- a/alkos/kernel/CMakeLists.txt
+++ b/alkos/kernel/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories(${SYSROOT}/usr/include)
 include_directories(test)
 
 # Additional test definitions - refer to test/tester.hpp file for value specifics
-# add_compile_definitions(ALKOS_TEST=1)
+ add_compile_definitions(ALKOS_TEST=3)
 
 add_compile_definitions(__ALKOS_KERNEL__=1)
 add_compile_definitions(__SERIAL_PORT_TEST__=1)

--- a/alkos/kernel/CMakeLists.txt
+++ b/alkos/kernel/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories(${SYSROOT}/usr/include)
 include_directories(test)
 
 # Additional test definitions - refer to test/tester.hpp file for value specifics
- add_compile_definitions(ALKOS_TEST=3)
+# add_compile_definitions(ALKOS_TEST=1)
 
 add_compile_definitions(__ALKOS_KERNEL__=1)
 add_compile_definitions(__SERIAL_PORT_TEST__=1)

--- a/alkos/kernel/arch/x86_64/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/CMakeLists.txt
@@ -65,8 +65,7 @@ endif()
 ################################################################################
 
 set(SRTI_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cxx/crti.nasm")
-set(SRTN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cxx/crtn.nasm"
-        interrupts/idt.cpp)
+set(SRTN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cxx/crtn.nasm")
 
 add_library(alkos.kernel.crts OBJECT ${SRTI_FILE} ${SRTN_FILE})
 

--- a/alkos/kernel/arch/x86_64/CMakeLists.txt
+++ b/alkos/kernel/arch/x86_64/CMakeLists.txt
@@ -65,7 +65,8 @@ endif()
 ################################################################################
 
 set(SRTI_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cxx/crti.nasm")
-set(SRTN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cxx/crtn.nasm")
+set(SRTN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/cxx/crtn.nasm"
+        interrupts/idt.cpp)
 
 add_library(alkos.kernel.crts OBJECT ${SRTI_FILE} ${SRTN_FILE})
 

--- a/alkos/kernel/arch/x86_64/boot64.nasm
+++ b/alkos/kernel/arch/x86_64/boot64.nasm
@@ -49,6 +49,7 @@ boot64:
           call _fini
 
           ; Infinite loop
+          cli
 os_hang:
           hlt
           jmp os_hang

--- a/alkos/kernel/arch/x86_64/gdt64.nasm
+++ b/alkos/kernel/arch/x86_64/gdt64.nasm
@@ -43,5 +43,5 @@ GDT64:
           global kKernelCodeOffset
           global kKernelDataOffset
 
-          kKernelCodeOffset dq GDT64.Code
-          kKernelDataOffset dq GDT64.Data
+          kKernelCodeOffset dd GDT64.Code
+          kKernelDataOffset dd GDT64.Data

--- a/alkos/kernel/arch/x86_64/gdt64.nasm
+++ b/alkos/kernel/arch/x86_64/gdt64.nasm
@@ -40,3 +40,8 @@ GDT64:
           global GDT64.Pointer
           global GDT64.Code
           global GDT64.Data
+          global kKernelCodeOffset
+          global kKernelDataOffset
+
+          kKernelCodeOffset dq GDT64.Code
+          kKernelDataOffset dq GDT64.Data

--- a/alkos/kernel/arch/x86_64/include/arch_utils.hpp
+++ b/alkos/kernel/arch/x86_64/include/arch_utils.hpp
@@ -1,0 +1,11 @@
+#ifndef ARCH_X86_64_ARCH_UTILS_HPP_
+#define ARCH_X86_64_ARCH_UTILS_HPP_
+
+inline void OsHang() {
+    asm volatile("cli");
+    while (1) {
+        asm volatile("hlt");
+    }
+}
+
+#endif // ARCH_X86_64_ARCH_UTILS_HPP_

--- a/alkos/kernel/arch/x86_64/init.cpp
+++ b/alkos/kernel/arch/x86_64/init.cpp
@@ -1,0 +1,33 @@
+#if defined(__linux__)
+#error "You are not using a cross-compiler, you will most certainly run into trouble"
+#endif
+
+#if !defined(__x86_64__)
+#error "AlkOS needs to be compiled with a x86_64-elf compiler"
+#endif
+
+/* internal includes */
+#include <init.hpp>
+#include <debug.hpp>
+
+/* external init procedures */
+extern "C" void enable_osxsave();
+
+extern "C" void enable_sse();
+
+extern "C" void enable_avx();
+
+extern "C" void IdtInit();
+
+void KernelArchInit()
+{
+    /* NOTE: sequence is important */
+    TRACE_INFO("Setting up OS XSAVE...");
+    enable_osxsave();
+    TRACE_INFO("Setting up SSE...");
+    enable_sse();
+    TRACE_INFO("Setting up AVX...");
+    enable_avx();
+    TRACE_INFO("Setting up IDT...");
+    IdtInit();
+}

--- a/alkos/kernel/arch/x86_64/interrupts/idt.cpp
+++ b/alkos/kernel/arch/x86_64/interrupts/idt.cpp
@@ -1,0 +1,89 @@
+
+/* internal includes */
+#include <bit.hpp>
+#include <defines.hpp>
+#include <init.hpp>
+#include <panic.hpp>
+
+/* crucial defines */
+static constexpr u32 kIdtEntries  = 256;
+static constexpr u8 kDefaultFlags = 0x8E;
+
+/* gdt kernel code offset */
+extern "C" u32 kKernelCodeOffset;
+
+/* isr strub table initialized in nasm */
+extern "C" u64 *IsrStubTable;
+
+// ------------------------------
+// Data layout
+// ------------------------------
+
+struct PACK IdtEntry
+{
+    u16 isr_low;   // The lower 16 bits of the ISR's address
+    u16 kernel_cs; // The GDT segment selector that the CPU will load into CS before calling the ISR
+    u8 ist;        // The IST in the TSS that the CPU will load into RSP; set to zero for now
+    u8 attributes; // Type and attributes; see the IDT page
+    u16 isr_mid;   // The higher 16 bits of the lower 32 bits of the ISR's address
+    u32 isr_high;  // The higher 32 bits of the ISR's address
+    u32 reserved;  // Set to zero
+};
+
+struct PACK Idtr
+{
+    u16 limit;
+    u64 base;
+};
+
+// ------------------------------
+// Global data
+// ------------------------------
+
+alignas(32) static bool g_idtGuards[kIdtEntries];
+alignas(32) static IdtEntry g_idt[kIdtEntries];
+alignas(32) static Idtr g_idtr;
+
+// ------------------------------
+// Isrs
+// ------------------------------
+
+extern "C" NO_RET void DefaultExceptionHandler()
+{
+    KernelPanic("Unknown Exception caught -> default handler invoked.");
+}
+
+// ------------------------------
+// Functions
+// ------------------------------
+
+static void IdtSetDescriptor(const u8 idx, const u64 isr, const u8 flags)
+{
+    IdtEntry &entry = g_idt[idx];
+
+    entry.isr_low    = reinterpret_cast<uint64_t>(isr) & kBitMask16;
+    entry.kernel_cs  = kKernelCodeOffset;
+    entry.ist        = 0;
+    entry.attributes = flags;
+    entry.isr_mid    = (reinterpret_cast<uint64_t>(isr) >> 16) & kBitMask16;
+    entry.isr_high   = (reinterpret_cast<uint64_t>(isr) >> 32) & kBitMask32;
+    entry.reserved   = 0;
+
+    g_idtGuards[idx] = true;
+}
+
+static void IdtInit()
+{
+    g_idtr.base  = reinterpret_cast<uintptr_t>(g_idt);
+    g_idtr.limit = static_cast<u16>(sizeof(IdtEntry)) * kIdtEntries - 1;
+
+    for (u8 idx = 0; idx < 32; idx++)
+    {
+        IdtSetDescriptor(idx, IsrStubTable[idx], kDefaultFlags);
+    }
+
+    __asm__ volatile("lidt %0" : : "m"(g_idtr)); // load the new IDT
+    __asm__ volatile("sti");                     // set the interrupt flag
+}
+
+void InitInterrupts() { IdtInit(); }

--- a/alkos/kernel/arch/x86_64/interrupts/idt.cpp
+++ b/alkos/kernel/arch/x86_64/interrupts/idt.cpp
@@ -92,7 +92,7 @@ static void IdtSetDescriptor(const u8 idx, const u64 isr, const u8 flags)
     g_idtGuards[idx] = true;
 }
 
-static void IdtInit()
+extern "C" void IdtInit()
 {
     ASSERT(kKernelCodeOffset < UINT16_MAX && "Kernel code offset out of range");
     ASSERT_NEQ(0, kKernelCodeOffset);
@@ -114,8 +114,3 @@ static void IdtInit()
     __asm__ volatile("lidt %0" : : "m"(g_idtr)); // load the new IDT
     __asm__ volatile("sti");                     // set the interrupt flag
 }
-
-/**
- * @brief implementation of Hardware Abstraction Layer function
- */
-void InitInterrupts() { IdtInit(); }

--- a/alkos/kernel/arch/x86_64/interrupts/idt.cpp
+++ b/alkos/kernel/arch/x86_64/interrupts/idt.cpp
@@ -1,4 +1,3 @@
-
 /* internal includes */
 #include <bit.hpp>
 #include <debug.hpp>
@@ -7,20 +6,28 @@
 #include <kernel_assert.hpp>
 #include <panic.hpp>
 
+TODO_BY_THE_END_OF_MILESTONE0
+/**
+ * @todo Add various debug traces when snprintf available
+ */
+
 /* crucial defines */
 static constexpr u32 kIdtEntries  = 256;
 static constexpr u8 kDefaultFlags = 0x8E;
 
 /* gdt kernel code offset */
-extern "C" u64 kKernelCodeOffset;
+extern "C" u32 kKernelCodeOffset;
 
 /* isr stub table initialized in nasm */
-extern "C" u64 *IsrStubTable;
+extern "C" void *IsrStubTable[];
 
 // ------------------------------
 // Data layout
 // ------------------------------
 
+/**
+ * @brief Data layout of x86_64 interrupt service routines, refer to intel manual for details
+ */
 struct PACK IdtEntry
 {
     u16 isr_low;   // The lower 16 bits of the ISR's address
@@ -32,6 +39,9 @@ struct PACK IdtEntry
     u32 reserved;  // Set to zero
 };
 
+/**
+ * @brief Structure describing Idt position in memory
+ */
 struct PACK Idtr
 {
     u16 limit;
@@ -42,8 +52,13 @@ struct PACK Idtr
 // Global data
 // ------------------------------
 
-alignas(16) static bool g_idtGuards[kIdtEntries];
-alignas(16) static IdtEntry g_idt[kIdtEntries];
+/* vector holding bool to detect double assignment */
+alignas(32) static bool g_idtGuards[kIdtEntries];
+
+/* global strcture defining isr specifics for each interrupt signal */
+alignas(32) static IdtEntry g_idt[kIdtEntries];
+
+/* holds information about the idt position in memory */
 static Idtr g_idtr;
 
 // ------------------------------
@@ -62,17 +77,16 @@ extern "C" NO_RET void DefaultExceptionHandler()
 
 static void IdtSetDescriptor(const u8 idx, const u64 isr, const u8 flags)
 {
-    ASSERT(kKernelCodeOffset < UINT16_MAX && "Kernel code offset out of range");
     ASSERT_EQ(false, g_idtGuards[idx]);
 
     IdtEntry &entry = g_idt[idx];
 
-    entry.isr_low    = reinterpret_cast<u64>(isr) & kBitMask16;
+    entry.isr_low    = isr & kBitMask16;
     entry.kernel_cs  = kKernelCodeOffset;
     entry.ist        = 0;
     entry.attributes = flags;
-    entry.isr_mid    = (reinterpret_cast<u64>(isr) >> 16) & kBitMask16;
-    entry.isr_high   = (reinterpret_cast<u64>(isr) >> 32) & kBitMask32;
+    entry.isr_mid    = (isr >> 16) & kBitMask16;
+    entry.isr_high   = (isr >> 32) & kBitMask32;
     entry.reserved   = 0;
 
     g_idtGuards[idx] = true;
@@ -80,12 +94,21 @@ static void IdtSetDescriptor(const u8 idx, const u64 isr, const u8 flags)
 
 static void IdtInit()
 {
+    ASSERT(kKernelCodeOffset < UINT16_MAX && "Kernel code offset out of range");
+    ASSERT_NEQ(0, kKernelCodeOffset);
+
     g_idtr.base  = reinterpret_cast<uintptr_t>(g_idt);
     g_idtr.limit = static_cast<u16>(sizeof(IdtEntry)) * kIdtEntries - 1;
 
-    for (u8 idx = 0; idx < 32; idx++)
+    /* cleanup flag vector */
+    for (bool &g_idtGuard : g_idtGuards)
     {
-        IdtSetDescriptor(idx, IsrStubTable[idx], kDefaultFlags);
+        g_idtGuard = false;
+    }
+
+    for (u8 idx = 0; idx < 32; ++idx)
+    {
+        IdtSetDescriptor(idx, reinterpret_cast<u64>(IsrStubTable[idx]), kDefaultFlags);
     }
 
     __asm__ volatile("lidt %0" : : "m"(g_idtr)); // load the new IDT

--- a/alkos/kernel/arch/x86_64/interrupts/idt.cpp
+++ b/alkos/kernel/arch/x86_64/interrupts/idt.cpp
@@ -115,4 +115,7 @@ static void IdtInit()
     __asm__ volatile("sti");                     // set the interrupt flag
 }
 
+/**
+ * @brief implementation of Hardware Abstraction Layer function
+ */
 void InitInterrupts() { IdtInit(); }

--- a/alkos/kernel/arch/x86_64/interrupts/idt.nasm
+++ b/alkos/kernel/arch/x86_64/interrupts/idt.nasm
@@ -1,0 +1,56 @@
+; Scheme copied from osdev.org
+; Simplifies definition of idt
+
+%macro isr_err_stub 1
+isr_stub_%+%1:
+    call DefaultExceptionHandler
+    iretq
+%endmacro
+
+%macro isr_no_err_stub 1
+isr_stub_%+%1:
+    call DefaultExceptionHandler
+    iretq
+%endmacro
+
+extern DefaultExceptionHandler
+isr_no_err_stub 0
+isr_no_err_stub 1
+isr_no_err_stub 2
+isr_no_err_stub 3
+isr_no_err_stub 4
+isr_no_err_stub 5
+isr_no_err_stub 6
+isr_no_err_stub 7
+isr_err_stub    8
+isr_no_err_stub 9
+isr_err_stub    10
+isr_err_stub    11
+isr_err_stub    12
+isr_err_stub    13
+isr_err_stub    14
+isr_no_err_stub 15
+isr_no_err_stub 16
+isr_err_stub    17
+isr_no_err_stub 18
+isr_no_err_stub 19
+isr_no_err_stub 20
+isr_no_err_stub 21
+isr_no_err_stub 22
+isr_no_err_stub 23
+isr_no_err_stub 24
+isr_no_err_stub 25
+isr_no_err_stub 26
+isr_no_err_stub 27
+isr_no_err_stub 28
+isr_no_err_stub 29
+isr_err_stub    30
+isr_no_err_stub 31
+
+global IsrStubTable
+IsrStubTable:
+%assign i 0
+%rep    32
+    dq isr_stub_%+i
+%assign i i+1
+%endrep

--- a/alkos/kernel/arch/x86_64/interrupts/idt.nasm
+++ b/alkos/kernel/arch/x86_64/interrupts/idt.nasm
@@ -13,7 +13,11 @@ isr_stub_%+%1:
     iretq
 %endmacro
 
+bits 64
+
 extern DefaultExceptionHandler
+
+section .text
 isr_no_err_stub 0
 isr_no_err_stub 1
 isr_no_err_stub 2
@@ -46,6 +50,8 @@ isr_no_err_stub 28
 isr_no_err_stub 29
 isr_err_stub    30
 isr_no_err_stub 31
+
+section .data
 
 global IsrStubTable
 IsrStubTable:

--- a/alkos/kernel/arch/x86_64/linker.ld
+++ b/alkos/kernel/arch/x86_64/linker.ld
@@ -22,17 +22,17 @@ SECTIONS
 	/* First put the multiboot header, as it is required to be put very early
 	   in the image or the bootloader won't recognize the file format.
 	   Next we'll put the .text section. */
-          .multiboot ALIGN(64) : AT(.)
-          {
-	          KEEP(*(.multiboot))
+    .multiboot ALIGN(64) : AT(.)
+    {
+        KEEP(*(.multiboot))
 	}
 
 	. = ALIGN(4K);
 
 	.text32 BLOCK(4K) : ALIGN(4K)
-          {
-                    *(.text32)
-          }
+    {
+        *(.text32)
+    }
 
 
 	.text BLOCK(4K) : ALIGN(4K)

--- a/alkos/kernel/include/bit.hpp
+++ b/alkos/kernel/include/bit.hpp
@@ -1,6 +1,11 @@
 #ifndef KERNEL_INCLUDE_BIT_HPP_
 #define KERNEL_INCLUDE_BIT_HPP_
 
+#include <types.hpp>
 
+static constexpr u64 kBitMask8 = 0xFF;
+static constexpr u64 kBitMask16 = kBitMask8 | (kBitMask8 << 8);
+static constexpr u64 kBitMask32 = kBitMask16 | (kBitMask16 << 16);
+static constexpr u64 kBitMask64 = kBitMask32 | (kBitMask32 << 32);
 
 #endif // KERNEL_INCLUDE_BIT_HPP_

--- a/alkos/kernel/include/bit.hpp
+++ b/alkos/kernel/include/bit.hpp
@@ -1,0 +1,6 @@
+#ifndef KERNEL_INCLUDE_BIT_HPP_
+#define KERNEL_INCLUDE_BIT_HPP_
+
+
+
+#endif // KERNEL_INCLUDE_BIT_HPP_

--- a/alkos/kernel/include/bit.hpp
+++ b/alkos/kernel/include/bit.hpp
@@ -3,6 +3,7 @@
 
 #include <types.hpp>
 
+static constexpr u64 kBitMask4 = 0xF;
 static constexpr u64 kBitMask8 = 0xFF;
 static constexpr u64 kBitMask16 = kBitMask8 | (kBitMask8 << 8);
 static constexpr u64 kBitMask32 = kBitMask16 | (kBitMask16 << 16);

--- a/alkos/kernel/include/defines.hpp
+++ b/alkos/kernel/include/defines.hpp
@@ -1,6 +1,12 @@
 #ifndef KERNEL_INCLUDE_DEFINES_HPP_
 #define KERNEL_INCLUDE_DEFINES_HPP_
 
+#include <types.hpp>
+
+#define PACK __attribute__ ((__packed__))
+
+#define NO_RET __attribute__((noreturn))
+
 #define FORCE_INLINE inline __attribute__((always_inline))
 
 #define WRAP_CALL FORCE_INLINE
@@ -13,5 +19,10 @@ static constexpr bool kSerialPortTest = true;
 #else
 static constexpr bool kSerialPortTest = false;
 #endif // __SERIAL_PORT_TEST__
+
+static constexpr u64 kBitMask8 = 0xFF;
+static constexpr u64 kBitMask16 = kBitMask8 | (kBitMask8 << 8);
+static constexpr u64 kBitMask32 = kBitMask16 | (kBitMask16 << 16);
+static constexpr u64 kBitMask64 = kBitMask32 | (kBitMask32 << 32);
 
 #endif // KERNEL_INCLUDE_DEFINES_HPP_

--- a/alkos/kernel/include/defines.hpp
+++ b/alkos/kernel/include/defines.hpp
@@ -1,8 +1,6 @@
 #ifndef KERNEL_INCLUDE_DEFINES_HPP_
 #define KERNEL_INCLUDE_DEFINES_HPP_
 
-#include <types.hpp>
-
 #define PACK __attribute__ ((__packed__))
 
 #define NO_RET __attribute__((noreturn))
@@ -19,10 +17,5 @@ static constexpr bool kSerialPortTest = true;
 #else
 static constexpr bool kSerialPortTest = false;
 #endif // __SERIAL_PORT_TEST__
-
-static constexpr u64 kBitMask8 = 0xFF;
-static constexpr u64 kBitMask16 = kBitMask8 | (kBitMask8 << 8);
-static constexpr u64 kBitMask32 = kBitMask16 | (kBitMask16 << 16);
-static constexpr u64 kBitMask64 = kBitMask32 | (kBitMask32 << 32);
 
 #endif // KERNEL_INCLUDE_DEFINES_HPP_

--- a/alkos/kernel/include/init.hpp
+++ b/alkos/kernel/include/init.hpp
@@ -6,6 +6,6 @@ void KernelInit();
 /**
  * @brief must be defined by arch code to set up all architecture dependent interrupt settings
  */
-void InitInterrupts();
+void KernelArchInit();
 
 #endif // ALKOS_INCLUDE_INIT_HPP_

--- a/alkos/kernel/include/init.hpp
+++ b/alkos/kernel/include/init.hpp
@@ -3,4 +3,9 @@
 
 void KernelInit();
 
+/**
+ * @brief must be defined by arch code to set up all architecture dependent interrupt settings
+ */
+void InitInterrupts();
+
 #endif // ALKOS_INCLUDE_INIT_HPP_

--- a/alkos/kernel/include/kernel_assert.hpp
+++ b/alkos/kernel/include/kernel_assert.hpp
@@ -1,0 +1,72 @@
+#ifndef KERNEL_INCLUDE_ASSERT_HPP_
+#define KERNEL_INCLUDE_ASSERT_HPP_
+
+#include <defines.hpp>
+#include <panic.hpp>
+#include <todo.hpp>
+
+// ------------------------------
+// Int type asserts
+// ------------------------------
+
+#define FAIL_KERNEL(expr)                                                                                              \
+    KernelPanic("Assertion failed: " TOSTRING(expr) " at file: " __FILE__ " and line: " TOSTRING(__LINE__));
+
+/* c-like debug only assert */
+#ifdef NDEBUG
+
+#define ASSERT(expr)
+
+#else
+
+#define ASSERT(expr)                                                                                                   \
+    if (!(expr))                                                                                                       \
+    {                                                                                                                  \
+        FAIL_KERNEL(expr);                                                                                             \
+    }
+
+#endif // NDEBUG
+
+/* release assert */
+#define ASSERT_ALWAYS(expr)                                                                                            \
+    if (!(expr))                                                                                                       \
+    {                                                                                                                  \
+        FAIL_KERNEL(expr);                                                                                             \
+    }
+
+// ------------------------------
+// Verbose asserts
+// ------------------------------
+
+/**
+ * Verbose assertions to compare expected and actual values.
+ *
+ * @param expected The expected value.
+ * @param value The actual value.
+ *
+ * TODO: Add descriptive prints to these macros when snprintf or equivalent
+ * functionality becomes available. This will improve the clarity of assertion
+ * failures by providing detailed context.
+ *
+ * Additionally, consider defining the following macros for greater versatility:
+ * - ASSERT_LT(expected, value): Checks if `expected` is less than `value`.
+ * - ASSERT_GT(expected, value): Checks if `expected` is greater than `value`.
+ * - ASSERT_LE(expected, value): Checks if `expected` is less than or equal to `value`.
+ * - ASSERT_GE(expected, value): Checks if `expected` is greater than or equal to `value`.
+ */
+
+TODO_BY_THE_END_OF_MILESTONE0
+
+#define ASSERT_EQ(expected, value)                                                                                     \
+    if (expected != value)                                                                                             \
+    {                                                                                                                  \
+        FAIL_KERNEL(expected != value);                                                                                \
+    }
+
+#define ASSERT_NEQ(expected, value)                                                                                    \
+    if (expected == value)                                                                                             \
+    {                                                                                                                  \
+        FAIL_KERNEL(expected == value);                                                                                \
+    }
+
+#endif // KERNEL_INCLUDE_ASSERT_HPP_

--- a/alkos/kernel/include/temp.hpp
+++ b/alkos/kernel/include/temp.hpp
@@ -1,0 +1,69 @@
+#ifndef KERNEL_INCLUDE_TEMP_HPP_
+#define KERNEL_INCLUDE_TEMP_HPP_
+
+/**
+ * @brief collection of implementation details that must be removed in close future by replacing with real
+ * implementation
+ */
+
+#include <terminal.hpp>
+#include <types.hpp>
+#include <todo.hpp>
+
+TODO_BY_THE_END_OF_MILESTONE0
+
+inline const char *temp_ToStringHex(const u64 x)
+{
+    static char buf[17];
+    buf[16] = '\0';
+
+    for (i64 iter = 60, cur = 0; iter >= 0; iter -= 4)
+    {
+        const u64 value = (x >> iter) & kBitMask4;
+        buf[cur++] = (value < 10) ? ('0' + value) : ('A' + value - 10);
+    }
+
+    return buf;
+}
+
+inline const char *temp_ToString(u64 x)
+{
+    static char buf[64];
+    static char stack[64];
+
+    u64 cur = 0;
+    while (x > 0)
+    {
+        const u64 value = x % 10;
+        stack[cur++]    = '0' + value;
+
+        x /= 10;
+    }
+
+    u64 bufCur = 0;
+    while (cur > 0)
+    {
+        buf[bufCur++] = stack[--cur];
+    }
+    buf[bufCur] = '\0';
+
+    return buf;
+}
+
+inline void temp_DisplayHex(const u64 x, const char *msg)
+{
+    TerminalWriteString(msg);
+    TerminalWriteString(": ");
+    TerminalWriteString(temp_ToStringHex(x));
+    TerminalPutChar('\n');
+}
+
+inline void temp_DisplayNum(const u64 x, const char *msg)
+{
+    TerminalWriteString(msg);
+    TerminalWriteString(": ");
+    TerminalWriteString(temp_ToString(x));
+    TerminalPutChar('\n');
+}
+
+#endif // KERNEL_INCLUDE_TEMP_HPP_

--- a/alkos/kernel/include/temp.hpp
+++ b/alkos/kernel/include/temp.hpp
@@ -1,14 +1,14 @@
 #ifndef KERNEL_INCLUDE_TEMP_HPP_
 #define KERNEL_INCLUDE_TEMP_HPP_
 
-/**
- * @brief collection of implementation details that must be removed in close future by replacing with real
- * implementation
- */
-
 #include <terminal.hpp>
 #include <types.hpp>
 #include <todo.hpp>
+
+/**
+ * @todo collection of implementation details that must be removed in close future by replacing with real
+ * implementation
+ */
 
 TODO_BY_THE_END_OF_MILESTONE0
 

--- a/alkos/kernel/include/todo.hpp
+++ b/alkos/kernel/include/todo.hpp
@@ -1,0 +1,18 @@
+#ifndef KERNEL_INCLUDE_TODO_HPP_
+#define KERNEL_INCLUDE_TODO_HPP_
+
+/**
+ * @brief This file's purpose is to define a set of macros used as placeholders
+ * for tasks that need to be addressed before specific project milestones.
+ * These macros serve as markers for areas requiring further development,
+ * testing, or refactoring. All macros defined here are temporary and should
+ * be removed upon completion of the tasks they represent.
+ *
+ * Note: Removing such a macro will result in compilation errors in the areas
+ * marked by the macro, ensuring that all associated tasks are resolved
+ * before the codebase progresses to the next milestone.
+ */
+
+#define TODO_BY_THE_END_OF_MILESTONE0
+
+#endif // KERNEL_INCLUDE_TODO_HPP_

--- a/alkos/kernel/include/types.hpp
+++ b/alkos/kernel/include/types.hpp
@@ -5,4 +5,18 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+/* simplified int types */
+using u8 = uint8_t;
+using u16 = uint16_t;
+using u32 = uint32_t;
+using u64 = uint64_t;
+
+using i8 = int8_t;
+using i16 = int16_t;
+using i32 = int32_t;
+using i64 = int64_t;
+
+using f32 = float;
+using f64 = double;
+
 #endif // KERNEL_INCLUDE_TYPES_HPP_

--- a/alkos/kernel/include/types.hpp
+++ b/alkos/kernel/include/types.hpp
@@ -5,17 +5,19 @@
 #include <stddef.h>
 #include <stdbool.h>
 
-/* simplified int types */
+/* simplified unsigned int types */
 using u8 = uint8_t;
 using u16 = uint16_t;
 using u32 = uint32_t;
 using u64 = uint64_t;
 
+/* simplified int types */
 using i8 = int8_t;
 using i16 = int16_t;
 using i32 = int32_t;
 using i64 = int64_t;
 
+/* simplified float types */
 using f32 = float;
 using f64 = double;
 

--- a/alkos/kernel/src/init.cpp
+++ b/alkos/kernel/src/init.cpp
@@ -21,7 +21,6 @@ extern "C" void PreKernelInit() {
 
     TerminalInit();
     TRACE_INFO("Starting pre-kernel initialization...");
-    __stack_chk_init();
 
     /* NOTE: sequence is important */
     TRACE_INFO("Starting to setup CPU features...");
@@ -33,8 +32,13 @@ extern "C" void PreKernelInit() {
     enable_avx();
     TRACE_INFO("Finished cpu features setup.");
 
+    TRACE_INFO("Setting up IDT...");
+    InitInterrupts();
+    TRACE_INFO("IDT setup done.");
+
     TRACE_INFO("Pre-kernel initialization finished.");
 }
 
 void KernelInit() {
+    __stack_chk_init();
 }

--- a/alkos/kernel/src/init.cpp
+++ b/alkos/kernel/src/init.cpp
@@ -13,12 +13,6 @@ extern "C" void enable_sse();
 extern "C" void enable_avx();
 
 extern "C" void PreKernelInit() {
-    /**
-     * TODO:
-     * 1. Enable interrupts
-     * 2. GDT, IDT, TSS, etc.
-     */
-
     TerminalInit();
     TRACE_INFO("Starting pre-kernel initialization...");
 

--- a/alkos/kernel/src/init.cpp
+++ b/alkos/kernel/src/init.cpp
@@ -5,30 +5,13 @@
 #include <terminal.hpp>
 #include <debug.hpp>
 
-/* external init procedures */
-extern "C" void enable_osxsave();
-
-extern "C" void enable_sse();
-
-extern "C" void enable_avx();
-
 extern "C" void PreKernelInit() {
     TerminalInit();
     TRACE_INFO("Starting pre-kernel initialization...");
 
-    /* NOTE: sequence is important */
     TRACE_INFO("Starting to setup CPU features...");
-    TRACE_INFO("Setting up OS XSAVE...");
-    enable_osxsave();
-    TRACE_INFO("Setting up SSE...");
-    enable_sse();
-    TRACE_INFO("Setting up AVX...");
-    enable_avx();
+    KernelArchInit();
     TRACE_INFO("Finished cpu features setup.");
-
-    TRACE_INFO("Setting up IDT...");
-    InitInterrupts();
-    TRACE_INFO("IDT setup done.");
 
     TRACE_INFO("Pre-kernel initialization finished.");
 }

--- a/alkos/kernel/src/kernel.cpp
+++ b/alkos/kernel/src/kernel.cpp
@@ -25,7 +25,7 @@ extern "C" void KernelMain() {
 
 #ifdef ALKOS_TEST
 
-    TRACE_INFO("Running tests: " TOSTRING(ALKOS_TEST));
+    TRACE_INFO("Running test: " TOSTRING(ALKOS_TEST));
     VERIFY_TEST_TYPE(ALKOS_TEST)
     RunTest(static_cast<TestType>(ALKOS_TEST));
     TerminalWriteString("Hello from AlkOS test!");

--- a/alkos/kernel/src/kernel.cpp
+++ b/alkos/kernel/src/kernel.cpp
@@ -1,11 +1,3 @@
-#if defined(__linux__)
-#error "You are not using a cross-compiler, you will most certainly run into trouble"
-#endif
-
-#if !defined(__x86_64__)
-#error "AlkOS needs to be compiled with a x86_64-elf compiler"
-#endif
-
 #ifdef ALKOS_TEST
 #include <tester.hpp>
 #endif

--- a/alkos/kernel/src/panic.cpp
+++ b/alkos/kernel/src/panic.cpp
@@ -1,13 +1,12 @@
 /* internal includes */
+#include <arch_utils.hpp>
 #include <panic.hpp>
 #include <terminal.hpp>
 
-extern "C" void KernelPanic(const char *msg) {
+extern "C" void KernelPanic(const char *msg)
+{
     TerminalWriteError("[ KERNEL PANIC ]\n");
     TerminalWriteError(msg);
 
-    asm volatile("cli");
-    while (1) {
-        asm volatile("hlt");
-    }
+    OsHang();
 }

--- a/alkos/kernel/src/tester.cpp
+++ b/alkos/kernel/src/tester.cpp
@@ -2,18 +2,19 @@
 #include <tester.hpp>
 
 /* external include */
-#include <stddef.h>
+#include <kernel_assert.hpp>
 #include <new.hpp>
 #include <panic.hpp>
+#include <terminal.hpp>
 
 // ---------------------------------------
 // cpp compatibility test components
 // ---------------------------------------
 
-class TestClass {
-public:
-    explicit TestClass(const int x): m_a(x), m_b(2 * x + 2) {
-    }
+class TestClass
+{
+    public:
+    explicit TestClass(const int x) : m_a(x), m_b(2 * x + 2) {}
 
     int m_a;
     const int m_b;
@@ -21,7 +22,8 @@ public:
 
 TestClass g_GlobalTestClass(5);
 
-static void CppTest() {
+static void CppTest()
+{
     char mem[sizeof(TestClass)];
 
     /* Test static initializer */
@@ -37,13 +39,11 @@ static void CppTest() {
     delete[] test3;
 
     /* test placement new and delete */
-    auto *test4 = new(reinterpret_cast<TestClass *>(mem)) TestClass(5);
+    auto *test4 = new (reinterpret_cast<TestClass *>(mem)) TestClass(5);
     test4->m_a++;
 
     /* test global object */
-    if (g_GlobalTestClass.m_b != 12) {
-        KernelPanic("Global object initialization failed");
-    }
+    ASSERT_EQ(12, g_GlobalTestClass.m_b);
 }
 
 // ------------------------------
@@ -53,13 +53,15 @@ static void CppTest() {
 /**
  * @brief Test should drop kernel panic due to stack smashing
  */
-static void StackSmashTest() {
+static void StackSmashTest()
+{
     static constexpr uint64_t kStackSize = 32;
     static constexpr uint64_t kWriteSize = 64;
 
     char buff[kStackSize];
 
-    for (size_t i = 0; i < kWriteSize; i++) {
+    for (size_t i = 0; i < kWriteSize; i++)
+    {
         buff[i] = 'A';
     }
 }
@@ -69,11 +71,25 @@ static void StackSmashTest() {
 // ------------------------------
 
 /**
-* @brief Test should not drop kernel panic due to enabled float extension
-*
-* @note This test is architecture dependent, simply invokes floating point instructions
-*/
+ * @brief Test should not drop kernel panic due to enabled float extension
+ *
+ * @note This test is architecture dependent, simply invokes floating point instructions
+ */
 extern void FloatExtensionTest();
+
+// ------------------------------
+// Simple Exception test
+// ------------------------------
+
+/**
+ *  @brief Test should simply drop 0 division exception
+ *
+ */
+static void ExceptionTest()
+{
+    int a = 9 / 0;
+    TerminalWriteString("Exception test failed\n");
+}
 
 // ------------------------------
 // Test table
@@ -84,11 +100,10 @@ static TestFuncType TestTable[]{
     StackSmashTest,
     CppTest,
     FloatExtensionTest,
+    ExceptionTest,
 };
 
 static constexpr uint64_t kTestTableSize = sizeof(TestTable) == 0 ? 0 : sizeof(TestTable) / sizeof(TestTable[0]);
 static_assert(kTestTableSize == kLastTest, "TestTable does not contain all tests");
 
-void RunTest(const TestType type) {
-    TestTable[static_cast<uint64_t>(type)]();
-}
+void RunTest(const TestType type) { TestTable[static_cast<uint64_t>(type)](); }

--- a/alkos/kernel/test/tester.hpp
+++ b/alkos/kernel/test/tester.hpp
@@ -2,11 +2,13 @@
 #define ALKOS_TEST_TESTER_HPP_
 
 #include <stdint.h>
+#include <defines.hpp>
 
 enum TestType: uint64_t {
     kStackSmashTest,
     kCppTest,
     kFloatExtensionTest,
+    kExceptionTest,
     kLastTest,
 };
 
@@ -17,9 +19,6 @@ enum TestType: uint64_t {
 #endif
 
 #endif
-
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
 
 #define VERIFY_TEST_TYPE(type)                                                \
 static_assert(type < TestType::kLastTest,                                     \

--- a/scripts/env/arch_packages.txt
+++ b/scripts/env/arch_packages.txt
@@ -7,3 +7,4 @@ gmp
 libmpc
 mpfr
 base-devel
+wget


### PR DESCRIPTION
Things done in this PR:
- added stub array of isrs (Interrupt Service Routines),
- initialized IDT (Interrupt description table for 64bit code),
- added temporary code to print numeric values,
- added todo.hpp header,
- added initial asserts,
- added testing verifying if 0 division exception is correctly caught

Example execution log:
```
[INFO]	  Initializing Alkos
[OK]	  Detected Multiboot support
[OK]	  Detected CPUID support
[OK]	  Detected long mode support
[OK]	  Setup page tables
[OK]	  Enabled long mode
[OK]	  Enabled paging
[INFO]	  Jumping to 64-bit mode
[OK]	  In 64-bit mode
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/init.cpp 17 Starting pre-kernel initialization...
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/init.cpp 20 Starting to setup CPU features...
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/init.cpp 21 Setting up OS XSAVE...
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/init.cpp 23 Setting up SSE...
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/init.cpp 25 Setting up AVX...
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/init.cpp 27 Finished cpu features setup.
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/init.cpp 29 Setting up IDT...
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/init.cpp 31 IDT setup done.
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/init.cpp 33 Pre-kernel initialization finished.
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/kernel.cpp 23 Running kernel initialization...
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/src/kernel.cpp 28 Running test: 3
[INFO] /home/Jlisowskyy/Repos/AlkOS/alkos/kernel/arch/x86_64/interrupts/idt.cpp 70 Exception caught...
[ KERNEL PANIC ]
Unknown Exception caught -> default handler invoked.
```