### PR TITLE
Implement formatting and string manipulation functions

### DIFF
--- a/alkos/libc/include/defines.hpp
+++ b/alkos/libc/include/defines.hpp
@@ -13,5 +13,7 @@ static constexpr bool kIsKernel = false;
 
 #define INLINE inline __attribute__((always_inline))
 #define API_CALL INLINE
+#define WRAP_CALL INLINE
+#define FAST_CALL INLINE
 
 #endif // LIBC_INCLUDE_DEFINES_HPP_

--- a/alkos/libc/include/math.h
+++ b/alkos/libc/include/math.h
@@ -1,9 +1,31 @@
 #ifndef MATH_H_
 #define MATH_H_
 
+/**********************************************
+ * Constants
+ **********************************************/
+
+static constexpr double M_E        = 2.7182818284590452354;  // e
+static constexpr double M_LOG2E    = 1.4426950408889634074;  // log2(e)
+static constexpr double M_LOG10E   = 0.43429448190325182765; // log10(e)
+static constexpr double M_LN2      = 0.69314718055994530942; // ln(2)
+static constexpr double M_LN10     = 2.30258509299404568402; // ln(10)
+static constexpr double M_PI       = 3.14159265358979323846; // pi
+static constexpr double M_PI_2     = 1.57079632679489661923; // pi/2
+static constexpr double M_PI_4     = 0.78539816339744830962; // pi/4
+static constexpr double M_1_PI     = 0.31830988618379067154; // 1/pi
+static constexpr double M_2_PI     = 0.63661977236758134308; // 2/pi
+static constexpr double M_2_SQRTPI = 1.12837916709551257390; // 2/sqrt(pi)
+static constexpr double M_SQRT2    = 1.41421356237309504880; // sqrt(2)
+static constexpr double M_SQRT1_2  = 0.70710678118654752440; // 1/sqrt(2)
+
+/**********************************************
+ * Math functions
+ **********************************************/
+
 double modf(double num, double *integralPart);
 bool isnan(double num);
 bool isinf(double num);
-double abs(double num);
+double fabs(double num);
 
 #endif // MATH_H_

--- a/alkos/libc/include/math.h
+++ b/alkos/libc/include/math.h
@@ -6,4 +6,4 @@ bool isnan(double num);
 bool isinf(double num);
 double abs(double num);
 
-#endif //MATH_H_
+#endif // MATH_H_

--- a/alkos/libc/include/math.h
+++ b/alkos/libc/include/math.h
@@ -1,5 +1,5 @@
-#ifndef MATH_H_
-#define MATH_H_
+#ifndef LIBC_INCLUDE_MATH_H_
+#define LIBC_INCLUDE_MATH_H_
 
 /**********************************************
  * Constants
@@ -28,4 +28,4 @@ bool isnan(double num);
 bool isinf(double num);
 double fabs(double num);
 
-#endif // MATH_H_
+#endif // LIBC_INCLUDE_MATH_H_

--- a/alkos/libc/include/math.h
+++ b/alkos/libc/include/math.h
@@ -1,0 +1,9 @@
+#ifndef MATH_H_
+#define MATH_H_
+
+double modf(double num, double *integralPart);
+bool isnan(double num);
+bool isinf(double num);
+double abs(double num);
+
+#endif //MATH_H_

--- a/alkos/libc/include/stdio.h
+++ b/alkos/libc/include/stdio.h
@@ -4,7 +4,14 @@
 #include <stdarg.h>
 #include <stddef.h>
 
+/**
+ *  Writes formatted output to a character array (*str) up to a maximum amount of characters (size)
+ */
 int snprintf(char *str, size_t size, const char *format, ...);
+
+/**
+ *  Writes formatted data from a variable argument list (va) to a sized buffer (str, size)
+ */
 int vsnprintf(char *str, size_t size, const char *format, va_list va);
 
 #endif // STDIO_H_

--- a/alkos/libc/include/stdio.h
+++ b/alkos/libc/include/stdio.h
@@ -7,4 +7,4 @@
 int snprintf(char *str, size_t size, const char *format, ...);
 int vsnprintf(char *str, size_t size, const char *format, va_list va);
 
-#endif //STDIO_H_
+#endif // STDIO_H_

--- a/alkos/libc/include/stdio.h
+++ b/alkos/libc/include/stdio.h
@@ -1,5 +1,5 @@
-#ifndef STDIO_H_
-#define STDIO_H_
+#ifndef LIBC_INCLUDE_STDIO_H_
+#define LIBC_INCLUDE_STDIO_H_
 
 #include <stdarg.h>
 #include <stddef.h>
@@ -14,4 +14,4 @@ int snprintf(char *str, size_t size, const char *format, ...);
  */
 int vsnprintf(char *str, size_t size, const char *format, va_list va);
 
-#endif // STDIO_H_
+#endif // LIBC_INCLUDE_STDIO_H_

--- a/alkos/libc/include/stdio.h
+++ b/alkos/libc/include/stdio.h
@@ -1,0 +1,10 @@
+#ifndef STDIO_H_
+#define STDIO_H_
+
+#include <stdarg.h>
+#include <stddef.h>
+
+int snprintf(char *str, size_t size, const char *format, ...);
+int vsnprintf(char *str, size_t size, const char *format, va_list va);
+
+#endif //STDIO_H_

--- a/alkos/libc/include/string.h
+++ b/alkos/libc/include/string.h
@@ -3,14 +3,52 @@
 
 #include <stddef.h>
 
+/**
+ *  Returns the length of the string `str`
+ */
 size_t strlen(const char *str);
+
+/**
+ *  Copies `src`, including the null terminator, to `dst`
+ */
 char *strcpy(char *dest, const char *src);
+
+/**
+ *  Same as `strcpy`, but copies at most `n` characters
+ */
 char *strncpy(char *dest, const char *src, size_t n);
+
+/**
+ *  Compares two strings.
+ *  If the return is 0, the strings are equal.
+ *  If the return is less then 0, the first character that does not match has a lower value in s1 than s2.
+ *  If the return is greater then 0, the first character that does not match has a greater value in s1 than in s2
+ */
 int strcmp(const char *str1, const char *str2);
+
+/**
+ *  Same as `strcmp`, but compares at most `n` characters
+ */
 int strncmp(const char *str1, const char *str2, size_t n);
+
+/**
+ *  Appends the string `src` to the end of `dest`
+ */
 char *strcat(char *dest, const char *src);
+
+/**
+ *  Same as `strcat`, but appends at most `n` characters
+ */
 char *strncat(char *dest, const char *src, size_t n);
-char *strchr(const char *s, int c);
-char *strrchr(const char *s, int c);
+
+/**
+ *  Returns a pointer to the first occurence of `c` in string `str`
+ */
+char *strchr(const char *str, int c);
+
+/**
+ *  Returns a pointer to the last occurence of `c` in string `str`
+ */
+char *strrchr(const char *str, int c);
 
 #endif // STRING_H_

--- a/alkos/libc/include/string.h
+++ b/alkos/libc/include/string.h
@@ -1,5 +1,5 @@
-#ifndef STRING_H_
-#define STRING_H_
+#ifndef LIBC_INCLUDE_STRING_H_
+#define LIBC_INCLUDE_STRING_H_
 
 #include <stddef.h>
 
@@ -51,4 +51,4 @@ char *strchr(const char *str, int c);
  */
 char *strrchr(const char *str, int c);
 
-#endif // STRING_H_
+#endif // LIBC_INCLUDE_STRING_H_

--- a/alkos/libc/include/string.h
+++ b/alkos/libc/include/string.h
@@ -4,13 +4,13 @@
 #include <stddef.h>
 
 size_t strlen(const char *str);
-char* strcpy(char *dest, const char *src);
-char* strncpy(char *dest, const char *src, size_t n);
+char *strcpy(char *dest, const char *src);
+char *strncpy(char *dest, const char *src, size_t n);
 int strcmp(const char *str1, const char *str2);
 int strncmp(const char *str1, const char *str2, size_t n);
-char* strcat(char *dest, const char *src);
-char* strncat(char *dest, const char *src, size_t n);
+char *strcat(char *dest, const char *src);
+char *strncat(char *dest, const char *src, size_t n);
 char *strchr(const char *s, int c);
 char *strrchr(const char *s, int c);
 
-#endif //STRING_H_
+#endif // STRING_H_

--- a/alkos/libc/include/string.h
+++ b/alkos/libc/include/string.h
@@ -1,0 +1,16 @@
+#ifndef STRING_H_
+#define STRING_H_
+
+#include <stddef.h>
+
+size_t strlen(const char *str);
+char* strcpy(char *dest, const char *src);
+char* strncpy(char *dest, const char *src, size_t n);
+int strcmp(const char *str1, const char *str2);
+int strncmp(const char *str1, const char *str2, size_t n);
+char* strcat(char *dest, const char *src);
+char* strncat(char *dest, const char *src, size_t n);
+char *strchr(const char *s, int c);
+char *strrchr(const char *s, int c);
+
+#endif //STRING_H_

--- a/alkos/libc/include/types.h
+++ b/alkos/libc/include/types.h
@@ -1,0 +1,38 @@
+#ifndef LIBC_INCLUDE_TYPES_H_
+#define LIBC_INCLUDE_TYPES_H_
+
+#include "stdint.h"
+
+#if SIZE_MAX == UINTMAX_MAX
+typedef intmax_t ssize_t;
+#elif SIZE_MAX == ULONG_LONG_MAX
+typedef long long ssize_t;
+#elif SIZE_MAX == ULONG_MAX
+typedef long ssize_t;
+#elif SIZE_MAX == UINT_MAX
+typedef int ssize_t;
+#elif SIZE_MAX == USHRT_MAX
+typede short ssize_t;
+#elif SIZE_MAX == UCHAR_MAX
+typedef signed char ssize_t;
+#else
+#error "Unsupported ssize_t size"
+#endif
+
+#if PTRDIFF_MAX == INTMAX_MAX
+typedef uintmax_t uptrdiff_t;
+#elif PTRDIFF_MAX == LONG_LONG_MAX
+typedef unsigned long long uptrdiff_t;
+#elif PTRDIFF_MAX == LONG_MAX
+typedef unsigned long uptrdiff_t;
+#elif PTRDIFF_MAX == INT_MAX
+typedef unsigned int uptrdiff_t;
+#elif PTRDIFF_MAX == SHRT_MAX
+typede unsigned short uptrdiff_t;
+#elif PTRDIFF_MAX == CHAR_MAX
+typedef unsigned char uptrdiff_t;
+#else
+#error "Unsupported uptrdiff_t size"
+#endif
+
+#endif // LIBC_INCLUDE_TYPES_H_

--- a/alkos/libc/io/snprintf.cpp
+++ b/alkos/libc/io/snprintf.cpp
@@ -1,0 +1,1140 @@
+#include "math.h"
+#include "stdio.h"
+#include "string.h"
+
+#include <stdarg.h>
+#include <stdint.h>
+
+static size_t GetDecimal(char **s);
+static void ReverseString(char *s, size_t len);
+static size_t RemoveTrailingZeros(char *str);
+static void ShiftStringRight(char *str);
+static int RoundFormattedDoubleDecimal(char *str, bool scientific);
+static bool RoundFormattedDoubleHex(char *str, char lower);
+
+static double ipow(unsigned int base, int n);
+static int ilog(double num, unsigned int base);
+static bool IsNegative(double num);
+static bool IsSubNormal(double num);
+
+static char *FormatHex(uintmax_t num, char *str, int lower, bool prefix, int precision, bool zero_padding, int width);
+static char *FormatOct(uintmax_t num, char *str, bool prefix, int precision, bool zero_padding, int width);
+static char *FormatUInt(uintmax_t num, char *str);
+
+template <bool scientific>
+static char *FormatDouble(
+    double num, char *str, unsigned int precision, char lower, bool trailZeros, bool hashForm,
+    bool significantDigits = false
+);
+static char *FormatDoubleHex(
+    double num, char *str, int precision, char lower, bool trailZeros, bool hashForm, bool zero_padding, int width
+);
+
+// ------------------------------------------------------------------------------------
+
+static constexpr int BUFFER_SIZE              = 1024;
+static constexpr int DOUBLE_PRECISION_DIG     = 6;
+static constexpr int DOUBLE_HEX_PRECISION_DIG = 13;
+static constexpr double INTEGRAL_PRECISION    = 1e-4;
+static constexpr double FACTORIAL_PRECISION   = 1e-16;
+
+enum class LengthModifier
+{
+    None = '\0',
+    H    = 'H', // hh
+    h    = 'h', // h
+    L    = 'L', // ll
+    l    = 'l', // l
+    z    = 'z'  // z
+};
+
+#define SETCHAR(c)                                                                                                     \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (size > 0)                                                                                                  \
+        {                                                                                                              \
+            str[i < static_cast<int>(size) ? i : size - 1] = (c);                                                      \
+            ++i;                                                                                                       \
+        }                                                                                                              \
+    } while (0)
+
+/**
+ * Implementation of snprintf with support for various format specifiers
+ *
+ * This implementation provides formatting support for:
+ * - Integers (d, i, u)
+ * - Hexadecimal (x, X, p)
+ * - Octal (o)
+ * - Floating point (f, F, e, E, g, G, a, A)
+ * - Strings (s)
+ * - Characters (c)
+ */
+int snprintf(char *str, size_t size, const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    const int ret = vsnprintf(str, size, format, args);
+    va_end(args);
+    return ret;
+}
+
+int vsnprintf(char *str, size_t size, const char *format, va_list va)
+{
+    int i = 0;
+    char buf[BUFFER_SIZE]; // TODO: Calculate buffer size
+    const char *prefix;
+    char *data;
+    int width, precision;
+    size_t conversion_length = 0;
+    bool reverse_padding = false, zero_padding = false, isHash = false, isSpace = false, isPlus = false;
+    auto length_modifier = LengthModifier::None;
+
+    // Iterate over the format string
+    for (auto iter = const_cast<char *>(format);; ++iter)
+    {
+        if (*iter == '\0')
+        {
+            if (size > 0)
+                str[i < static_cast<int>(size) ? i : size - 1] = '\0';
+            return i;
+        }
+
+        if (*iter != '%')
+        {
+            SETCHAR(*iter);
+            continue;
+        }
+
+        width           = -1;
+        precision       = -1;
+        prefix          = "";
+        reverse_padding = false;
+        zero_padding    = false;
+        isHash          = false;
+        isSpace         = false;
+        isPlus          = false;
+        length_modifier = LengthModifier::None;
+        data            = buf;
+
+        ++iter;
+
+        // Parse format specifiers
+        while (true)
+        {
+            switch (*iter)
+            {
+            case '\0':
+                return -1;
+
+            case '%':
+                str[i++] = '%';
+                break;
+
+            case '-':
+                reverse_padding = true;
+                ++iter;
+                continue;
+
+            case '.':
+                precision = 0;
+                ++iter;
+                continue;
+
+            case '0':
+                if (width < 0 && precision < 0 && !zero_padding && !reverse_padding)
+                {
+                    zero_padding = true;
+                    ++iter;
+                    continue;
+                }
+                // fall through
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                if (precision >= 0)
+                    precision = static_cast<int>(GetDecimal(&iter));
+                else
+                    width = static_cast<int>(GetDecimal(&iter));
+                continue;
+
+            case '*':
+            {
+                if (precision >= 0)
+                {
+                    precision = va_arg(va, int);
+                }
+                else
+                {
+                    width = va_arg(va, int);
+                    if (width < 0)
+                    {
+                        width *= -1;
+                        reverse_padding = true;
+                    }
+                }
+                ++iter;
+                continue;
+            }
+
+            case '+':
+                isPlus = true;
+                ++iter;
+                continue;
+
+            case ' ':
+                isSpace = true;
+                ++iter;
+                continue;
+
+            case '#':
+                isHash = true;
+                ++iter;
+                continue;
+
+            case 'h':
+            case 'l':
+            case 'z':
+            case 'Z':
+                if (static_cast<LengthModifier>(*iter) == LengthModifier::h && length_modifier == LengthModifier::h)
+                {
+                    length_modifier = LengthModifier::H;
+                }
+                else if (static_cast<LengthModifier>(*iter) == LengthModifier::l &&
+                         length_modifier == LengthModifier::l)
+                {
+                    length_modifier = LengthModifier::L;
+                }
+                else if (length_modifier == LengthModifier::None)
+                {
+                    length_modifier = static_cast<LengthModifier>((*iter & 0x20) ? *iter : *iter + 32);
+                }
+                else
+                {
+                    SETCHAR('%');
+                    SETCHAR(*iter);
+                    break;
+                }
+                ++iter;
+                continue;
+
+            case 'd':
+            case 'i':
+            case 'u':
+            {
+                uintmax_t d;
+
+                if (length_modifier == LengthModifier::z)
+                {
+                    if (*iter == 'u')
+                        d = va_arg(va, uintmax_t);
+                    else
+                        d = va_arg(va, intmax_t);
+                }
+                else if (length_modifier == LengthModifier::L)
+                {
+                    if (*iter == 'u')
+                        d = va_arg(va, unsigned long long);
+                    else
+                        d = va_arg(va, long long);
+                }
+                else if (length_modifier == LengthModifier::l)
+                {
+                    if (*iter == 'u')
+                        d = va_arg(va, unsigned long);
+                    else
+                        d = va_arg(va, long);
+                }
+                else if (length_modifier == LengthModifier::h)
+                {
+                    if (*iter == 'u')
+                        d = static_cast<unsigned short>(va_arg(va, unsigned int));
+                    else
+                        d = static_cast<short>(va_arg(va, int));
+                }
+                else if (length_modifier == LengthModifier::H)
+                {
+                    if (*iter == 'u')
+                        d = static_cast<unsigned char>(va_arg(va, unsigned int));
+                    else
+                        d = static_cast<char>(va_arg(va, int));
+                }
+                else if (*iter == 'u')
+                {
+                    d = va_arg(va, unsigned int);
+                }
+                else
+                {
+                    d = va_arg(va, int);
+                }
+
+                if (*iter != 'u' && static_cast<intmax_t>(d) < 0)
+                {
+                    d *= -1;
+                    prefix = "-";
+                    width--;
+                }
+                else if (isPlus)
+                {
+                    prefix = "+";
+                    width--;
+                }
+                else if (isSpace)
+                {
+                    prefix = " ";
+                    width--;
+                }
+
+                FormatUInt(d, data);
+                conversion_length = strlen(data);
+
+                break;
+            }
+
+            case 'p':
+            case 'x':
+            case 'X':
+            {
+                uintmax_t x;
+
+                if (*iter == 'p')
+                {
+                    x = reinterpret_cast<uintptr_t>(va_arg(va, void *));
+                    if (x == 0)
+                    {
+                        strcpy(data, "(nil)");
+                        conversion_length = 5;
+                        zero_padding      = false;
+                        precision         = 0;
+                        break;
+                    }
+                    isHash = true;
+                }
+                else if (length_modifier == LengthModifier::L)
+                {
+                    x = va_arg(va, unsigned long long);
+                }
+                else if (length_modifier == LengthModifier::l)
+                {
+                    x = va_arg(va, unsigned long);
+                }
+                else if (length_modifier == LengthModifier::h)
+                {
+                    x = static_cast<unsigned short>(va_arg(va, unsigned int));
+                }
+                else if (length_modifier == LengthModifier::H)
+                {
+                    x = static_cast<unsigned char>(va_arg(va, unsigned int));
+                }
+                else
+                {
+                    x = va_arg(va, unsigned int);
+                }
+
+                if (precision >= 0)
+                {
+                    FormatHex(x, data, *iter & 0x20, isHash, precision, true, -1);
+                    zero_padding = false;
+                }
+                else if (zero_padding)
+                {
+                    FormatHex(x, data, *iter & 0x20, isHash, -1, zero_padding, width);
+                    if (x != 0)
+                        zero_padding = false;
+                }
+                else
+                    FormatHex(x, data, *iter & 0x20, isHash, -1, false, -1);
+
+                conversion_length = strlen(data);
+
+                break;
+            }
+
+            case 'o':
+            {
+                uintmax_t x;
+
+                if (length_modifier == LengthModifier::L)
+                {
+                    x = va_arg(va, unsigned long long);
+                }
+                else if (length_modifier == LengthModifier::l)
+                {
+                    x = va_arg(va, unsigned long);
+                }
+                else if (length_modifier == LengthModifier::h)
+                {
+                    x = static_cast<unsigned short>(va_arg(va, unsigned int));
+                }
+                else if (length_modifier == LengthModifier::H)
+                {
+                    x = static_cast<unsigned char>(va_arg(va, unsigned int));
+                }
+                else
+                {
+                    x = va_arg(va, unsigned int);
+                }
+
+                if (precision >= 0)
+                {
+                    FormatOct(x, data, isHash, precision, true, -1);
+                    zero_padding = false;
+                }
+                else if (zero_padding)
+                {
+                    FormatOct(x, data, isHash, -1, zero_padding, width);
+                    if (x != 0)
+                        zero_padding = false;
+                }
+                else
+                    FormatOct(x, data, isHash, -1, false, -1);
+
+                conversion_length = strlen(data);
+
+                break;
+            }
+
+            case 'f':
+            case 'F':
+            case 'e':
+            case 'E':
+            case 'g':
+            case 'G':
+            case 'a':
+            case 'A':
+            {
+                double f = va_arg(va, double);
+
+                // f < 0 does not work for nan, checking sign bit instead
+                if (IsNegative(f))
+                {
+                    f *= -1;
+                    prefix = "-";
+                    width--;
+                }
+                else if (isPlus)
+                {
+                    prefix = "+";
+                    width--;
+                }
+                else if (isSpace)
+                {
+                    prefix = " ";
+                    width--;
+                }
+
+                if (isnan(f))
+                {
+                    for (size_t j = 0; j < 3; ++j) data[j] = "NAN"[j] | (*iter & 0x20);
+                    conversion_length = 3;
+                    zero_padding      = false;
+                    precision         = 0;
+                    break;
+                }
+
+                if (isinf(f))
+                {
+                    for (size_t j = 0; j < 3; ++j) data[j] = "INF"[j] | (*iter & 0x20);
+                    conversion_length = 3;
+                    zero_padding      = false;
+                    precision         = 0;
+                    break;
+                }
+
+                switch (*iter | 0x20)
+                {
+                case 'f':
+                    FormatDouble<false>(
+                        f, data, precision >= 0 ? precision : DOUBLE_PRECISION_DIG, *iter & 0x20, false, isHash
+                    );
+                    break;
+
+                case 'e':
+                    FormatDouble<true>(
+                        f, data, precision >= 0 ? precision : DOUBLE_PRECISION_DIG, *iter & 0x20, false, isHash
+                    );
+                    break;
+
+                case 'g':
+                {
+                    int e             = ilog(f, 10);
+                    int num_precision = precision >= 0 ? precision : DOUBLE_PRECISION_DIG;
+                    if ((e >= num_precision || e < -4) && (e != num_precision || e != 0))
+                        FormatDouble<true>(f, data, num_precision, *iter & 0x20, true, isHash, true);
+                    else
+                    {
+                        FormatDouble<false>(f, data, num_precision, *iter & 0x20, true, isHash, true);
+                        if (zero_padding)
+                            precision = width;
+                        else
+                            precision = 0;
+                    }
+
+                    break;
+                }
+
+                case 'a':
+                    FormatDoubleHex(f, data, precision, *iter & 0x20, precision == -1, isHash, zero_padding, width);
+                    break;
+                }
+
+                conversion_length = strlen(data);
+
+                break;
+            }
+
+            case 's':
+            {
+                char *s = va_arg(va, char *);
+
+                if (s == nullptr)
+                {
+                    strcpy(data, "(null)");
+                    conversion_length = 6;
+                    zero_padding      = false;
+                    precision         = 0;
+                    break;
+                }
+
+                conversion_length = strlen(data);
+                if (precision >= 0 && conversion_length > static_cast<size_t>(precision))
+                {
+                    conversion_length = precision;
+                }
+
+                break;
+            }
+
+            case 'c':
+            {
+                char c = va_arg(va, int);
+
+                buf[0]            = c;
+                conversion_length = 1;
+                break;
+            }
+
+            default:
+                SETCHAR('%');
+                SETCHAR(*iter);
+                break;
+            }
+
+            // Add padding and width with formatted data to the output buffer
+
+            if (precision < 0 && zero_padding)
+                precision = width;
+
+            width -= conversion_length;
+            precision -= conversion_length;
+
+            if (precision > 0)
+                width -= precision;
+
+            if (!reverse_padding && !zero_padding)
+            {
+                while (width-- > 0)
+                {
+                    SETCHAR(' ');
+                }
+            }
+
+            while (*prefix)
+            {
+                SETCHAR(*prefix++);
+            }
+
+            while (precision-- > 0)
+            {
+                SETCHAR('0');
+            }
+
+            while (conversion_length-- > 0)
+            {
+                SETCHAR(*data++);
+            }
+
+            while (width-- > 0)
+            {
+                SETCHAR(' ');
+            }
+
+            break;
+        }
+    }
+}
+
+/**
+ *  String utilities
+ */
+
+static size_t GetDecimal(char **s)
+{
+    int i = 0;
+    while (**s >= '0' && **s <= '9') i = i * 10 + *(*s)++ - '0';
+    return i;
+}
+
+static void ReverseString(char *s, size_t len)
+{
+    if (!len)
+        return;
+
+    for (size_t i = 0, j = len - 1; i < j; i++, j--)
+    {
+        char tmp = s[i];
+        s[i]     = s[j];
+        s[j]     = tmp;
+    }
+}
+
+static inline void ShiftStringRight(char *str)
+{
+    size_t len = strlen(str);
+    for (size_t i = len + 1; i > 0; --i)
+    {
+        str[i] = str[i - 1];
+    }
+}
+
+static int RoundFormattedDoubleDecimal(char *str, bool scientific)
+{
+    char *end = str + strlen(str) - 1;
+    int carry = 0;
+
+    // Check if the last character needs to round up
+    if (*end >= '5')
+    {
+        carry = 1;
+        for (char *ptr = end - 1; ptr >= str; --ptr)
+        {
+            if (*ptr == '.')
+                continue;
+            int digit = (*ptr - '0') + carry;
+            *ptr      = '0' + (digit % 10);
+            carry     = digit / 10;
+            if (!carry)
+                break;
+        }
+        if (carry)
+        {
+            if (!scientific)
+                ShiftStringRight(str);
+            str[0] = '1';
+            end++;
+        }
+    }
+
+    *end = '\0';
+
+    // Return if carry propagated to exponent
+    return carry;
+}
+
+static bool RoundFormattedDoubleHex(char *str, char lower)
+{
+    char *end = str + strlen(str) - 1;
+    int carry = 0;
+
+    // Check if the last character needs to round up
+    if (*end == '8' || *end == '9' || *end >= ('A' | lower))
+    {
+        carry = 1;
+        for (char *ptr = end - 1; ptr >= str; --ptr)
+        {
+            if (*ptr == '.')
+                break;
+
+            int digit = (*ptr >= '0' && *ptr <= '9') ? (*ptr - '0') : ((*ptr & ~32) - 'A' + 10); // Convert to 0-15
+            digit += carry;
+
+            if (digit < 16)
+            {
+                *ptr  = (digit < 10) ? ('0' + digit) : (('A' | lower) + digit - 10); // Convert back to char
+                carry = 0;
+                break;
+            }
+            else
+            {
+                *ptr  = '0'; // Rollover
+                carry = 1;
+            }
+        }
+    }
+
+    *end = '\0';
+
+    // Return if carry propagated to exponent
+    return carry;
+}
+
+static size_t RemoveTrailingZeros(char *str)
+{
+    size_t i  = 0;
+    char *end = str + strlen(str) - 1;
+    while (end > str && *end == '0')
+    {
+        end--;
+        i++;
+    }
+    *(end + 1) = '\0';
+    return i;
+}
+
+/**
+ *  Double formatting utilities
+ */
+
+static double ipow(unsigned int base, int n)
+{
+    int i    = 1;
+    double p = 1.0, m;
+
+    if (n < 0)
+    {
+        n = -n;
+        m = 1.0 / base;
+    }
+    else
+    {
+        m = base;
+    }
+
+    for (; i <= n; i++)
+    {
+        p *= m;
+    }
+
+    return p;
+}
+
+static int ilog(double num, unsigned int base)
+{
+    int res = 0;
+
+    if (num == 0.0)
+    {
+        return 0;
+    }
+
+    if (num < 0)
+    {
+        num *= -1;
+    }
+
+    if (num < 1)
+    {
+        while (num < 1)
+        {
+            num *= base;
+            res--;
+        }
+    }
+    else
+    {
+        while (num >= base)
+        {
+            num /= base;
+            res++;
+        }
+    }
+
+    return res;
+}
+
+static inline bool IsNegative(double num)
+{
+    auto intdbl = reinterpret_cast<uint64_t *>(&num);
+    return (*intdbl & (1ULL << 63)) != 0;
+}
+
+static bool IsSubNormal(double num)
+{
+    auto intdbl         = reinterpret_cast<uint64_t *>(&num);
+    const auto exponent = static_cast<short>(*intdbl >> 52 & 0x7FF);
+    const auto mantisa  = *intdbl & (-1ULL >> 12);
+
+    if (exponent == 0)
+    {
+        if (mantisa == 0)
+            return false; // zero
+        else
+            return true; // subnormal
+    }
+    else if (exponent == 2047)
+    {
+        if (mantisa == 0)
+            return false; // inf
+        else
+            return false; // nan
+    }
+
+    return false; // normal
+}
+
+/**
+ *  Integer formatting utilities
+ */
+
+static char *FormatHex(uintmax_t num, char *str, int lower, bool prefix, int precision, bool zero_padding, int width)
+{
+    int i = 0;
+
+    if (num == 0)
+    {
+        if (precision == -1)
+            str[i++] = '0';
+        else
+        {
+            for (int j = 0; j < precision; ++j) str[i++] = '0';
+        }
+        str[i] = '\0';
+
+        return str;
+    }
+
+    for (; num; num >>= 4) str[i++] = "0123456789ABCDEF"[num & 15] | lower;
+
+    if (zero_padding)
+    {
+        int zeros = 0;
+        if (precision != -1)
+            zeros = precision - i;
+        else
+            zeros = width - i - ((prefix) ? 2 : 0);
+
+        for (int j = 0; j < zeros; ++j) str[i++] = '0';
+    }
+
+    if (prefix)
+    {
+        str[i++] = 'X' | lower;
+        str[i++] = '0';
+    }
+
+    str[i] = '\0';
+
+    ReverseString(str, i);
+
+    return str;
+}
+
+static char *FormatOct(uintmax_t num, char *str, bool prefix, int precision, bool zero_padding, int width)
+{
+    int i = 0;
+
+    if (num == 0)
+    {
+        if (precision == -1)
+            str[i++] = '0';
+        else
+        {
+            for (int j = 0; j < precision; ++j) str[i++] = '0';
+        }
+        str[i] = '\0';
+
+        return str;
+    }
+
+    for (; num; num >>= 3) str[i++] = '0' + (num & 7);
+
+    if (zero_padding)
+    {
+        int zeros = 0;
+        if (precision != -1)
+            zeros = precision - i - ((prefix) ? 1 : 0);
+        else
+            zeros = width - i - ((prefix) ? 1 : 0);
+
+        for (int j = 0; j < zeros; ++j) str[i++] = '0';
+    }
+
+    if (prefix)
+    {
+        str[i++] = '0';
+    }
+
+    str[i] = '\0';
+
+    ReverseString(str, i);
+
+    return str;
+}
+
+static char *FormatUInt(uintmax_t num, char *str)
+{
+    int i = 0;
+
+    if (num == 0)
+    {
+        str[i++] = '0';
+        str[i]   = '\0';
+
+        return str;
+    }
+
+    for (; num; num /= 10) str[i++] = '0' + num % 10;
+
+    str[i] = '\0';
+
+    ReverseString(str, i);
+
+    return str;
+}
+
+/**
+ *  Double formatting functions
+ */
+
+template <bool scientific>
+static char *FormatDouble(
+    double num, char *str, unsigned int precision, char lower, bool trailZeros, bool hashForm, bool significantDigits
+)
+{
+    size_t i                = 0;
+    int exp                 = 0; // Exponent
+    int subnormalCorrection = 0;
+    bool foundNonZero       = false;
+    size_t significantCount = 0;
+
+    if (significantDigits && precision == 0)
+        precision = 1;
+
+    // Normalize
+    if (scientific)
+    {
+        if (IsSubNormal(num))
+        {
+            subnormalCorrection = -(ilog(num, 10) + 308);
+            num *= ipow(10, subnormalCorrection);
+            exp = -308;
+        }
+        else
+            exp = ilog(num, 10);
+
+        if (exp < 0)
+            num *= ipow(10, -exp);
+        else
+            num /= ipow(10, exp);
+    }
+
+    double integralPart;
+    double fractionalPart = modf(num, &integralPart);
+
+    if (scientific)
+    {
+        int digit = static_cast<char>((modf(num / 10, &integralPart) + INTEGRAL_PRECISION) * 10);
+        str[i++]  = '0' + digit;
+    }
+    else
+    {
+        if (integralPart == 0.0)
+        {
+            str[i++] = '0';
+        }
+        else
+        {
+            for (num = integralPart; num != 0.0;)
+            {
+                num /= 10;
+                int digit = static_cast<char>((modf(num, &integralPart) + INTEGRAL_PRECISION) * 10);
+                str[i++]  = '0' + digit;
+                num       = integralPart;
+            }
+        }
+    }
+
+    // Reverse the integral part
+    if (!scientific)
+        ReverseString(str, i);
+
+    if (significantDigits)
+    {
+        for (size_t j = 0; j < i; ++j)
+        {
+            if (str[j] != '0' || foundNonZero)
+            {
+                foundNonZero = true;
+                if (++significantCount == precision)
+                    break;
+            }
+        }
+    }
+
+    // Add decimal point
+    if (precision > 0 || hashForm)
+    {
+        str[i++] = '.';
+    }
+
+    // Fractional part
+    for (size_t j = 0;; ++j)
+    {
+        char digit = static_cast<char>((fractionalPart + FACTORIAL_PRECISION) * 10);
+        if (digit < 0 || digit > 9)
+            break; // Underflow
+        str[i++]       = '0' + digit;
+        fractionalPart = (fractionalPart * 10) - static_cast<double>(digit);
+
+        if (significantDigits)
+        {
+            if (digit != 0 || foundNonZero)
+            {
+                foundNonZero = true;
+                if (++significantCount == precision + 1)
+                    break;
+            }
+            else if (num == 0.0 && j >= precision - 1)
+                break;
+        }
+        else if (j >= precision)
+            break;
+    }
+    str[i] = '\0';
+
+    int carry = RoundFormattedDoubleDecimal(str, scientific);
+    i--;
+
+    // Remove trailing zeros
+    if (trailZeros)
+    {
+        size_t count = 0;
+        if (!hashForm || str[i - 2] == '.')
+            count = RemoveTrailingZeros(str);
+        i -= count;
+
+        if ((count == precision && !hashForm) || (!hashForm && str[i - 1] == '.'))
+            i--;
+    }
+
+    if (carry)
+        exp++;
+
+    if (scientific)
+    {
+        str[i++] = 'E' | lower;
+
+        if (exp < 0)
+        {
+            exp *= -1;
+            str[i++] = '-';
+        }
+        else
+        {
+            str[i++] = '+';
+        }
+
+        if (exp < 10)
+            str[i++] = '0';
+
+        FormatUInt(exp + subnormalCorrection, str + i);
+
+        return str;
+    }
+    else
+    {
+        str[i] = '\0';
+
+        return str;
+    }
+}
+
+static char *FormatDoubleHex(
+    double num, char *str, int precision, char lower, bool trailZeros, bool hashForm, bool zero_padding, int width
+)
+{
+    size_t i = 0;
+    int exp  = ilog(num, 2); // Exponent
+
+    // TODO: Is it possible to remove this buffer?
+    char temp[BUFFER_SIZE];
+
+    // Add prefix
+    str[i++] = '0';
+    str[i++] = 'X' | lower;
+
+    if (num == 0.0)
+    {
+        str[i++] = '0';
+        if (hashForm || precision != -1)
+            str[i++] = '.';
+        while (precision-- > 0) str[i++] = '0';
+        str[i++] = 'P' | lower;
+        str[i++] = '+';
+        str[i++] = '0';
+        str[i]   = '\0';
+
+        return str;
+    }
+
+    precision = precision != -1 ? precision : DOUBLE_HEX_PRECISION_DIG;
+
+    i         = 0;
+    temp[i++] = '1';
+
+    // Add decimal point
+    if (precision > 0 || hashForm)
+        temp[i++] = '.';
+
+    const size_t frac = i;
+
+    // Normalize
+    if (exp < 0.0)
+        num *= ipow(2, -exp);
+    else
+        num /= ipow(2, exp);
+
+    // Fractional part
+    double integralPart;
+    double fractionalPart = modf(num, &integralPart);
+    for (int j = 0; j < precision + 1; ++j)
+    {
+        fractionalPart = modf(fractionalPart * 16, &integralPart);
+        temp[i++]      = "0123456789ABCDEF"[static_cast<char>(integralPart) & 15] | lower;
+    }
+    temp[i] = '\0';
+
+    bool carry = RoundFormattedDoubleHex(temp + frac, lower);
+    --i;
+
+    if (trailZeros)
+    {
+        size_t count = RemoveTrailingZeros(temp);
+        i -= count;
+
+        if (static_cast<int>(count) == precision && !hashForm)
+            i--;
+    }
+
+    if (carry)
+        exp++;
+
+    temp[i++] = 'P' | lower;
+
+    if (exp >= 0)
+    {
+        temp[i++] = '+';
+    }
+    else
+    {
+        exp *= -1;
+        temp[i++] = '-';
+    }
+
+    int len = strlen(FormatUInt(exp, temp + i));
+
+    // Add zero padding
+    {
+        size_t j;
+        for (j = 2; zero_padding && j < width - i - len; ++j) str[j] = '0';
+
+        strcpy(str + j, temp);
+    }
+
+    return str;
+}

--- a/alkos/libc/io/snprintf.cpp
+++ b/alkos/libc/io/snprintf.cpp
@@ -1,17 +1,18 @@
-#include "defines.hpp"
-#include "math.h"
 #include "stdio.h"
-#include "string.h"
 
 #include <stdarg.h>
 #include <stdint.h>
+
+#include "defines.hpp"
+#include "math.h"
+#include "string.h"
 
 static size_t GetDecimal(char **str);
 static void ReverseString(char *str, size_t len);
 static size_t RemoveTrailingZeros(char *str);
 static void ShiftStringRight(char *str);
 static int RoundFormattedDoubleDecimal(char *str, bool scientific);
-static bool RoundFormattedDoubleHex(char *str, char lower);
+static int RoundFormattedDoubleHex(char *str, char lower);
 
 static double ipow(unsigned int base, int n);
 static int ilog(double num, unsigned int base);
@@ -23,44 +24,36 @@ static char *FormatOct(uintmax_t num, char *str, bool prefix, int precision, boo
 static char *FormatUInt(uintmax_t num, char *str);
 
 template <bool scientific>
-static char *FormatDouble(
-    double num, char *str, unsigned int precision, char lower, bool trailZeros, bool hashForm,
-    bool significantDigits = false
-);
-static char *FormatDoubleHex(
-    double num, char *str, int precision, char lower, bool trailZeros, bool hashForm, bool zeroPadding, int width
-);
+static char *FormatDouble(double num, char *str, unsigned int precision, char lower, bool trailZeros, bool hashForm, bool significantDigits = false);
+static char *FormatDoubleHex(double num, char *str, int precision, char lower, bool trailZeros, bool hashForm, bool zeroPadding, int width);
 
-// ------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------
 
-static constexpr int IS_LOWER                 = 0x20; // If char is lowercase the 0x20 bit is set
-static constexpr int BUFFER_SIZE              = 1024;
-static constexpr int DOUBLE_PRECISION_DIG     = 6;
-static constexpr int DOUBLE_HEX_PRECISION_DIG = 13;
-static constexpr double INTEGRAL_PRECISION    = 1e-4;
-static constexpr double FACTORIAL_PRECISION   = 1e-16;
+// If char is lowercase the 0x20 bit is set
+static constexpr int kIsLower = 0x20;
+static constexpr int kBufferSize = 1024;
+static constexpr int kDoublePrecisionDigits = 6;
+static constexpr int kDoubleHexPrecisionDigits = 13;
+static constexpr double kIntegralPrecision = 1e-4;
+static constexpr double kFactorialPrecision = 1e-16;
 
-enum class LengthModifier
-{
+enum class LengthModifier {
     None = '\0',
-    H    = 'H', // hh
-    h    = 'h', // h
-    L    = 'L', // ll
-    l    = 'l', // l
-    z    = 'z'  // z
+    H = 'H',  // hh
+    h = 'h',  // h
+    L = 'L',  // ll
+    l = 'l',  // l
+    z = 'z'   // z
 };
 
-FAST_CALL static void PutChar(char *str, int &i, size_t size, char c)
-{
-    if (size > 0)
-    {
+FAST_CALL static void PutChar(char *str, int &i, size_t size, char c) {
+    if (size > 0) {
         str[i < static_cast<int>(size) ? i : size - 1] = c;
         ++i;
     }
 }
 
-int snprintf(char *str, size_t size, const char *format, ...)
-{
+int snprintf(char *str, size_t size, const char *format, ...) {
     va_list args;
     va_start(args, format);
     const int ret = vsnprintf(str, size, format, args);
@@ -68,491 +61,410 @@ int snprintf(char *str, size_t size, const char *format, ...)
     return ret;
 }
 
-int vsnprintf(char *str, size_t size, const char *format, va_list va)
-{
+int vsnprintf(char *str, size_t size, const char *format, va_list va) {
     int i = 0;
-    char buf[BUFFER_SIZE]; // TODO: Calculate buffer size
-    const char *prefix;
+    char buf[kBufferSize];  // TODO: Calculate buffer size
+    char prefix;
     char *data;
     int width, precision;
-    size_t conversionLength = 0;
-    bool reversePadding = false, zeroPadding = false, isHash = false, isSpace = false, isPlus = false;
-    auto lengthModifier = LengthModifier::None;
+    size_t conversion_length;
+    bool reverse_padding, zero_padding, is_hash, is_space, is_plus;
+    LengthModifier length_modifier;
 
     // Iterate over the format string
-    for (auto iter = const_cast<char *>(format);; ++iter)
-    {
-        if (*iter == '\0')
-        {
-            if (size > 0)
-                str[i < static_cast<int>(size) ? i : size - 1] = '\0';
-            return i;
+    for (auto iter = const_cast<char *>(format);; ++iter) {
+        if (*iter == '\0') {
+            PutChar(str, i, size, '\0');
+            return i - 1;  // PutChar increments i, so we need to subtract 1
         }
 
-        if (*iter != '%')
-        {
+        if (*iter != '%') {
             PutChar(str, i, size, *iter);
             continue;
         }
 
-        width          = -1;
-        precision      = -1;
-        prefix         = "";
-        reversePadding = false;
-        zeroPadding    = false;
-        isHash         = false;
-        isSpace        = false;
-        isPlus         = false;
-        lengthModifier = LengthModifier::None;
-        data           = buf;
+        width = -1;
+        precision = -1;
+        prefix = '\0';
+        reverse_padding = false;
+        zero_padding = false;
+        is_hash = false;
+        is_space = false;
+        is_plus = false;
+        length_modifier = LengthModifier::None;
+        data = buf;
 
         ++iter;
 
         // Parse format specifiers
-        while (true)
-        {
-            switch (*iter)
-            {
-            case '\0':
-                return -1;
-
-            case '%':
-                str[i++] = '%';
-                break;
-
-            case '-':
-                reversePadding = true;
-                ++iter;
-                continue;
-
-            case '.':
-                precision = 0;
-                ++iter;
-                continue;
-
-            case '0':
-                if (width < 0 && precision < 0 && !zeroPadding && !reversePadding)
-                {
-                    zeroPadding = true;
+        while (true) {
+            switch (*iter) {
+                case '\0': {
+                    return -1;
+                }
+                case '%': {
+                    str[i++] = '%';
+                    break;
+                }
+                case '-': {
+                    reverse_padding = true;
                     ++iter;
                     continue;
                 }
-                [[fallthrough]];
-            case '1':
-            case '2':
-            case '3':
-            case '4':
-            case '5':
-            case '6':
-            case '7':
-            case '8':
-            case '9':
-                if (precision >= 0)
-                    precision = static_cast<int>(GetDecimal(&iter));
-                else
-                    width = static_cast<int>(GetDecimal(&iter));
-                continue;
-
-            case '*':
-            {
-                if (precision >= 0)
-                {
-                    precision = va_arg(va, int);
+                case '.': {
+                    precision = 0;
+                    zero_padding = false;
+                    ++iter;
+                    continue;
                 }
-                else
-                {
-                    width = va_arg(va, int);
-                    if (width < 0)
-                    {
-                        width *= -1;
-                        reversePadding = true;
+                case '0': {
+                    if (width < 0 && precision < 0 && !zero_padding && !reverse_padding) {
+                        zero_padding = true;
+                        ++iter;
+                        continue;
                     }
+                    [[fallthrough]];
                 }
-                ++iter;
-                continue;
-            }
-
-            case '+':
-                isPlus = true;
-                ++iter;
-                continue;
-
-            case ' ':
-                isSpace = true;
-                ++iter;
-                continue;
-
-            case '#':
-                isHash = true;
-                ++iter;
-                continue;
-
-            case 'h':
-            case 'l':
-            case 'z':
-                if (static_cast<LengthModifier>(*iter) == LengthModifier::h && lengthModifier == LengthModifier::h)
-                {
-                    lengthModifier = LengthModifier::H;
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9': {
+                    if (precision >= 0) {
+                        precision = static_cast<int>(GetDecimal(&iter));
+                    } else {
+                        width = static_cast<int>(GetDecimal(&iter));
+                    }
+                    continue;
                 }
-                else if (static_cast<LengthModifier>(*iter) == LengthModifier::l && lengthModifier == LengthModifier::l)
-                {
-                    lengthModifier = LengthModifier::L;
+                case '*': {
+                    if (precision >= 0) {
+                        precision = va_arg(va, int);
+                    } else {
+                        width = va_arg(va, int);
+                        if (width < 0) {
+                            width *= -1;
+                            reverse_padding = true;
+                        }
+                    }
+                    ++iter;
+                    continue;
                 }
-                else if (lengthModifier == LengthModifier::None)
-                {
-                    lengthModifier = static_cast<LengthModifier>(*iter);
+                case '+': {
+                    is_plus = true;
+                    ++iter;
+                    continue;
                 }
-                else
-                {
+                case ' ': {
+                    is_space = true;
+                    ++iter;
+                    continue;
+                }
+                case '#': {
+                    is_hash = true;
+                    ++iter;
+                    continue;
+                }
+                case 'h':
+                case 'l':
+                case 'z': {
+                    auto modifier = static_cast<LengthModifier>(*iter);
+                    if (modifier == LengthModifier::h && length_modifier == LengthModifier::h) {
+                        length_modifier = LengthModifier::H;
+                    } else if (modifier == LengthModifier::l && length_modifier == LengthModifier::l) {
+                        length_modifier = LengthModifier::L;
+                    } else if (length_modifier == LengthModifier::None) {
+                        length_modifier = modifier;
+                    } else {
+                        PutChar(str, i, size, '%');
+                        PutChar(str, i, size, *iter);
+                        break;
+                    }
+                    ++iter;
+                    continue;
+                }
+                case 'd':
+                case 'i':
+                case 'u': {
+                    uintmax_t d;
+
+                    if (length_modifier == LengthModifier::z) {
+                        if (*iter == 'u') {
+                            d = va_arg(va, uintmax_t);
+                        } else {
+                            d = va_arg(va, intmax_t);
+                        }
+                    } else if (length_modifier == LengthModifier::L) {
+                        if (*iter == 'u') {
+                            d = va_arg(va, unsigned long long);
+                        } else {
+                            d = va_arg(va, long long);
+                        }
+                    } else if (length_modifier == LengthModifier::l) {
+                        if (*iter == 'u') {
+                            d = va_arg(va, unsigned long);
+                        } else {
+                            d = va_arg(va, long);
+                        }
+                    } else if (length_modifier == LengthModifier::h) {
+                        if (*iter == 'u') {
+                            d = static_cast<unsigned short>(va_arg(va, unsigned int));
+                        } else {
+                            d = static_cast<short>(va_arg(va, int));
+                        }
+                    } else if (length_modifier == LengthModifier::H) {
+                        if (*iter == 'u') {
+                            d = static_cast<unsigned char>(va_arg(va, unsigned int));
+                        } else {
+                            d = static_cast<char>(va_arg(va, int));
+                        }
+                    } else if (*iter == 'u') {
+                        d = va_arg(va, unsigned int);
+                    } else {
+                        d = va_arg(va, int);
+                    }
+
+                    if (*iter != 'u' && static_cast<intmax_t>(d) < 0) {
+                        d *= -1;
+                        prefix = '-';
+                        width--;
+                    } else if (is_plus) {
+                        prefix = '+';
+                        width--;
+                    } else if (is_space) {
+                        prefix = ' ';
+                        width--;
+                    }
+
+                    FormatUInt(d, data);
+                    conversion_length = strlen(data);
+
+                    break;
+                }
+                case 'p':
+                case 'x':
+                case 'X': {
+                    uintmax_t x;
+
+                    if (*iter == 'p') {
+                        x = reinterpret_cast<uintptr_t>(va_arg(va, void *));
+                        if (x == 0) {
+                            strcpy(data, "(nil)");
+                            conversion_length = 5;
+                            zero_padding = false;
+                            precision = 0;
+                            break;
+                        }
+                        is_hash = true;
+                    } else if (length_modifier == LengthModifier::L) {
+                        x = va_arg(va, unsigned long long);
+                    } else if (length_modifier == LengthModifier::l) {
+                        x = va_arg(va, unsigned long);
+                    } else if (length_modifier == LengthModifier::h) {
+                        x = static_cast<unsigned short>(va_arg(va, unsigned int));
+                    } else if (length_modifier == LengthModifier::H) {
+                        x = static_cast<unsigned char>(va_arg(va, unsigned int));
+                    } else {
+                        x = va_arg(va, unsigned int);
+                    }
+
+                    if (precision >= 0) {
+                        FormatHex(x, data, *iter & kIsLower, is_hash, precision, true, -1);
+                        zero_padding = false;
+                    } else if (zero_padding) {
+                        FormatHex(x, data, *iter & kIsLower, is_hash, -1, zero_padding, width);
+                        if (x != 0) {
+                            zero_padding = false;
+                        }
+                    } else {
+                        FormatHex(x, data, *iter & kIsLower, is_hash, -1, false, -1);
+                    }
+
+                    conversion_length = strlen(data);
+
+                    break;
+                }
+                case 'o': {
+                    uintmax_t x;
+
+                    if (length_modifier == LengthModifier::L) {
+                        x = va_arg(va, unsigned long long);
+                    } else if (length_modifier == LengthModifier::l) {
+                        x = va_arg(va, unsigned long);
+                    } else if (length_modifier == LengthModifier::h) {
+                        x = static_cast<unsigned short>(va_arg(va, unsigned int));
+                    } else if (length_modifier == LengthModifier::H) {
+                        x = static_cast<unsigned char>(va_arg(va, unsigned int));
+                    } else {
+                        x = va_arg(va, unsigned int);
+                    }
+
+                    if (precision >= 0) {
+                        FormatOct(x, data, is_hash, precision, true, -1);
+                        zero_padding = false;
+                    } else if (zero_padding) {
+                        FormatOct(x, data, is_hash, -1, zero_padding, width);
+                        if (x != 0) {
+                            zero_padding = false;
+                        }
+                    } else {
+                        FormatOct(x, data, is_hash, -1, false, -1);
+                    }
+
+                    conversion_length = strlen(data);
+
+                    break;
+                }
+                case 'f':
+                case 'F':
+                case 'e':
+                case 'E':
+                case 'g':
+                case 'G':
+                case 'a':
+                case 'A': {
+                    double f = va_arg(va, double);
+
+                    // f < 0 does not work for nan, checking sign bit instead
+                    if (IsNegative(f)) {
+                        f *= -1;
+                        prefix = '-';
+                        width--;
+                    } else if (is_plus) {
+                        prefix = '+';
+                        width--;
+                    } else if (is_space) {
+                        prefix = ' ';
+                        width--;
+                    }
+
+                    if (isnan(f)) {
+                        for (size_t j = 0; j < 3; ++j) {
+                            data[j] = "NAN"[j] | (*iter & kIsLower);
+                        }
+                        conversion_length = 3;
+                        zero_padding = false;
+                        precision = 0;
+                        break;
+                    }
+
+                    if (isinf(f)) {
+                        for (size_t j = 0; j < 3; ++j) {
+                            data[j] = "INF"[j] | (*iter & kIsLower);
+                        }
+                        conversion_length = 3;
+                        zero_padding = false;
+                        precision = 0;
+                        break;
+                    }
+
+                    switch (*iter | kIsLower) {
+                        case 'f': {
+                            FormatDouble<false>(f, data, precision >= 0 ? precision : kDoublePrecisionDigits, *iter & kIsLower, false, is_hash);
+                            break;
+                        }
+                        case 'e': {
+                            FormatDouble<true>(f, data, precision >= 0 ? precision : kDoublePrecisionDigits, *iter & kIsLower, false, is_hash);
+                            break;
+                        }
+                        case 'g': {
+                            int e = ilog(f, 10);
+                            int num_precision = precision >= 0 ? precision : kDoublePrecisionDigits;
+                            if ((e >= num_precision || e < -4) && (e != num_precision || e != 0)) {
+                                FormatDouble<true>(f, data, num_precision, *iter & kIsLower, true, is_hash, true);
+                            } else {
+                                FormatDouble<false>(f, data, num_precision, *iter & kIsLower, true, is_hash, true);
+                                if (zero_padding) {
+                                    precision = width;
+                                } else {
+                                    precision = 0;
+                                }
+                            }
+
+                            break;
+                        }
+                        case 'a': {
+                            FormatDoubleHex(f, data, precision, *iter & kIsLower, precision == -1, is_hash, zero_padding, width);
+                            break;
+                        }
+                    }
+
+                    conversion_length = strlen(data);
+                    precision = width;
+
+                    break;
+                }
+                case 's': {
+                    char *s = va_arg(va, char *);
+
+                    if (s == nullptr) {
+                        strcpy(data, "(null)");
+                        conversion_length = 6;
+                        zero_padding = false;
+                        precision = 0;
+                        break;
+                    }
+
+                    conversion_length = strlen(data);
+                    if (precision >= 0 && conversion_length > static_cast<size_t>(precision)) {
+                        conversion_length = precision;
+                    }
+
+                    break;
+                }
+                case 'c': {
+                    char c = va_arg(va, int);
+
+                    buf[0] = c;
+                    conversion_length = 1;
+                    break;
+                }
+                default: {
                     PutChar(str, i, size, '%');
                     PutChar(str, i, size, *iter);
                     break;
                 }
-                ++iter;
-                continue;
-
-            case 'd':
-            case 'i':
-            case 'u':
-            {
-                uintmax_t d;
-
-                if (lengthModifier == LengthModifier::z)
-                {
-                    if (*iter == 'u')
-                        d = va_arg(va, uintmax_t);
-                    else
-                        d = va_arg(va, intmax_t);
-                }
-                else if (lengthModifier == LengthModifier::L)
-                {
-                    if (*iter == 'u')
-                        d = va_arg(va, unsigned long long);
-                    else
-                        d = va_arg(va, long long);
-                }
-                else if (lengthModifier == LengthModifier::l)
-                {
-                    if (*iter == 'u')
-                        d = va_arg(va, unsigned long);
-                    else
-                        d = va_arg(va, long);
-                }
-                else if (lengthModifier == LengthModifier::h)
-                {
-                    if (*iter == 'u')
-                        d = static_cast<unsigned short>(va_arg(va, unsigned int));
-                    else
-                        d = static_cast<short>(va_arg(va, int));
-                }
-                else if (lengthModifier == LengthModifier::H)
-                {
-                    if (*iter == 'u')
-                        d = static_cast<unsigned char>(va_arg(va, unsigned int));
-                    else
-                        d = static_cast<char>(va_arg(va, int));
-                }
-                else if (*iter == 'u')
-                {
-                    d = va_arg(va, unsigned int);
-                }
-                else
-                {
-                    d = va_arg(va, int);
-                }
-
-                if (*iter != 'u' && static_cast<intmax_t>(d) < 0)
-                {
-                    d *= -1;
-                    prefix = "-";
-                    width--;
-                }
-                else if (isPlus)
-                {
-                    prefix = "+";
-                    width--;
-                }
-                else if (isSpace)
-                {
-                    prefix = " ";
-                    width--;
-                }
-
-                FormatUInt(d, data);
-                conversionLength = strlen(data);
-
-                break;
-            }
-
-            case 'p':
-            case 'x':
-            case 'X':
-            {
-                uintmax_t x;
-
-                if (*iter == 'p')
-                {
-                    x = reinterpret_cast<uintptr_t>(va_arg(va, void *));
-                    if (x == 0)
-                    {
-                        strcpy(data, "(nil)");
-                        conversionLength = 5;
-                        zeroPadding      = false;
-                        precision        = 0;
-                        break;
-                    }
-                    isHash = true;
-                }
-                else if (lengthModifier == LengthModifier::L)
-                {
-                    x = va_arg(va, unsigned long long);
-                }
-                else if (lengthModifier == LengthModifier::l)
-                {
-                    x = va_arg(va, unsigned long);
-                }
-                else if (lengthModifier == LengthModifier::h)
-                {
-                    x = static_cast<unsigned short>(va_arg(va, unsigned int));
-                }
-                else if (lengthModifier == LengthModifier::H)
-                {
-                    x = static_cast<unsigned char>(va_arg(va, unsigned int));
-                }
-                else
-                {
-                    x = va_arg(va, unsigned int);
-                }
-
-                if (precision >= 0)
-                {
-                    FormatHex(x, data, *iter & IS_LOWER, isHash, precision, true, -1);
-                    zeroPadding = false;
-                }
-                else if (zeroPadding)
-                {
-                    FormatHex(x, data, *iter & IS_LOWER, isHash, -1, zeroPadding, width);
-                    if (x != 0)
-                        zeroPadding = false;
-                }
-                else
-                    FormatHex(x, data, *iter & IS_LOWER, isHash, -1, false, -1);
-
-                conversionLength = strlen(data);
-
-                break;
-            }
-
-            case 'o':
-            {
-                uintmax_t x;
-
-                if (lengthModifier == LengthModifier::L)
-                {
-                    x = va_arg(va, unsigned long long);
-                }
-                else if (lengthModifier == LengthModifier::l)
-                {
-                    x = va_arg(va, unsigned long);
-                }
-                else if (lengthModifier == LengthModifier::h)
-                {
-                    x = static_cast<unsigned short>(va_arg(va, unsigned int));
-                }
-                else if (lengthModifier == LengthModifier::H)
-                {
-                    x = static_cast<unsigned char>(va_arg(va, unsigned int));
-                }
-                else
-                {
-                    x = va_arg(va, unsigned int);
-                }
-
-                if (precision >= 0)
-                {
-                    FormatOct(x, data, isHash, precision, true, -1);
-                    zeroPadding = false;
-                }
-                else if (zeroPadding)
-                {
-                    FormatOct(x, data, isHash, -1, zeroPadding, width);
-                    if (x != 0)
-                        zeroPadding = false;
-                }
-                else
-                    FormatOct(x, data, isHash, -1, false, -1);
-
-                conversionLength = strlen(data);
-
-                break;
-            }
-
-            case 'f':
-            case 'F':
-            case 'e':
-            case 'E':
-            case 'g':
-            case 'G':
-            case 'a':
-            case 'A':
-            {
-                double f = va_arg(va, double);
-
-                // f < 0 does not work for nan, checking sign bit instead
-                if (IsNegative(f))
-                {
-                    f *= -1;
-                    prefix = "-";
-                    width--;
-                }
-                else if (isPlus)
-                {
-                    prefix = "+";
-                    width--;
-                }
-                else if (isSpace)
-                {
-                    prefix = " ";
-                    width--;
-                }
-
-                if (isnan(f))
-                {
-                    for (size_t j = 0; j < 3; ++j) data[j] = "NAN"[j] | (*iter & IS_LOWER);
-                    conversionLength = 3;
-                    zeroPadding      = false;
-                    precision        = 0;
-                    break;
-                }
-
-                if (isinf(f))
-                {
-                    for (size_t j = 0; j < 3; ++j) data[j] = "INF"[j] | (*iter & IS_LOWER);
-                    conversionLength = 3;
-                    zeroPadding      = false;
-                    precision        = 0;
-                    break;
-                }
-
-                switch (*iter | IS_LOWER)
-                {
-                case 'f':
-                    FormatDouble<false>(
-                        f, data, precision >= 0 ? precision : DOUBLE_PRECISION_DIG, *iter & IS_LOWER, false, isHash
-                    );
-                    break;
-
-                case 'e':
-                    FormatDouble<true>(
-                        f, data, precision >= 0 ? precision : DOUBLE_PRECISION_DIG, *iter & IS_LOWER, false, isHash
-                    );
-                    break;
-
-                case 'g':
-                {
-                    int e             = ilog(f, 10);
-                    int num_precision = precision >= 0 ? precision : DOUBLE_PRECISION_DIG;
-                    if ((e >= num_precision || e < -4) && (e != num_precision || e != 0))
-                        FormatDouble<true>(f, data, num_precision, *iter & IS_LOWER, true, isHash, true);
-                    else
-                    {
-                        FormatDouble<false>(f, data, num_precision, *iter & IS_LOWER, true, isHash, true);
-                        if (zeroPadding)
-                            precision = width;
-                        else
-                            precision = 0;
-                    }
-
-                    break;
-                }
-
-                case 'a':
-                    FormatDoubleHex(f, data, precision, *iter & IS_LOWER, precision == -1, isHash, zeroPadding, width);
-                    break;
-                }
-
-                conversionLength = strlen(data);
-
-                break;
-            }
-
-            case 's':
-            {
-                char *s = va_arg(va, char *);
-
-                if (s == nullptr)
-                {
-                    strcpy(data, "(null)");
-                    conversionLength = 6;
-                    zeroPadding      = false;
-                    precision        = 0;
-                    break;
-                }
-
-                conversionLength = strlen(data);
-                if (precision >= 0 && conversionLength > static_cast<size_t>(precision))
-                {
-                    conversionLength = precision;
-                }
-
-                break;
-            }
-
-            case 'c':
-            {
-                char c = va_arg(va, int);
-
-                buf[0]           = c;
-                conversionLength = 1;
-                break;
-            }
-
-            default:
-                PutChar(str, i, size, '%');
-                PutChar(str, i, size, *iter);
-                break;
-
-            } // switch
+            }  // switch
 
             break;
         }
 
         // Add padding and width with formatted data to the output buffer
 
-        if (precision < 0 && zeroPadding)
+        if (precision < 0 && zero_padding) {
             precision = width;
+        }
 
-        width -= conversionLength;
-        precision -= conversionLength;
+        width -= conversion_length;
+        precision -= conversion_length;
 
-        if (precision > 0)
+        if (precision > 0) {
             width -= precision;
+        }
 
-        if (!reversePadding && !zeroPadding)
-        {
-            while (width-- > 0)
-            {
+        if (!reverse_padding && !zero_padding) {
+            while (width-- > 0) {
                 PutChar(str, i, size, ' ');
             }
         }
 
-        while (*prefix)
-        {
-            PutChar(str, i, size, *prefix++);
+        if (prefix) {
+            PutChar(str, i, size, prefix);
         }
 
-        while (precision-- > 0)
-        {
+        while (precision-- > 0) {
             PutChar(str, i, size, '0');
         }
 
-        while (conversionLength-- > 0)
-        {
+        while (conversion_length-- > 0) {
             PutChar(str, i, size, *data++);
         }
 
-        while (width-- > 0)
-        {
+        while (width-- > 0) {
             PutChar(str, i, size, ' ');
         }
     }
@@ -562,58 +474,52 @@ int vsnprintf(char *str, size_t size, const char *format, va_list va)
  *  String utilities
  */
 
-static size_t GetDecimal(char **str)
-{
+static size_t GetDecimal(char **str) {
     int i = 0;
-    while (**str >= '0' && **str <= '9') i = i * 10 + *(*str)++ - '0';
+    while (**str >= '0' && **str <= '9') {
+        i = i * 10 + *(*str)++ - '0';
+    }
     return i;
 }
 
-static void ReverseString(char *str, size_t len)
-{
-    if (!len)
-        return;
-
-    for (size_t i = 0, j = len - 1; i < j; i++, j--)
-    {
+static void ReverseString(char *str, size_t len) {
+    if (!len) return;
+    for (size_t i = 0, j = len - 1; i < j; i++, j--) {
         char tmp = str[i];
-        str[i]   = str[j];
-        str[j]   = tmp;
+        str[i] = str[j];
+        str[j] = tmp;
     }
 }
 
-static void ShiftStringRight(char *str)
-{
+static void ShiftStringRight(char *str) {
     size_t len = strlen(str);
-    for (size_t i = len + 1; i > 0; --i)
-    {
+    for (size_t i = len + 1; i > 0; --i) {
         str[i] = str[i - 1];
     }
 }
 
-static int RoundFormattedDoubleDecimal(char *str, bool scientific)
-{
+static int RoundFormattedDoubleDecimal(char *str, bool scientific) {
     char *end = str + strlen(str) - 1;
     int carry = 0;
 
     // Check if the last character needs to round up
-    if (*end >= '5')
-    {
+    if (*end >= '5') {
         carry = 1;
-        for (char *ptr = end - 1; ptr >= str; --ptr)
-        {
-            if (*ptr == '.')
-                continue;
+
+        for (char *ptr = end - 1; ptr >= str; --ptr) {
+            if (*ptr == '.') continue;
+
             int digit = (*ptr - '0') + carry;
-            *ptr      = '0' + (digit % 10);
-            carry     = digit / 10;
-            if (!carry)
-                break;
+            *ptr = '0' + (digit % 10);
+            carry = digit / 10;
+
+            if (!carry) break;
         }
-        if (carry)
-        {
-            if (!scientific)
+
+        if (carry) {
+            if (!scientific) {
                 ShiftStringRight(str);
+            }
             str[0] = '1';
             end++;
         }
@@ -625,32 +531,26 @@ static int RoundFormattedDoubleDecimal(char *str, bool scientific)
     return carry;
 }
 
-static bool RoundFormattedDoubleHex(char *str, char lower)
-{
+static int RoundFormattedDoubleHex(char *str, char lower) {
     char *end = str + strlen(str) - 1;
     int carry = 0;
 
     // Check if the last character needs to round up
-    if (*end == '8' || *end == '9' || *end >= ('A' | lower))
-    {
+    if (*end == '8' || *end == '9' || *end >= ('A' | lower)) {
         carry = 1;
-        for (char *ptr = end - 1; ptr >= str; --ptr)
-        {
-            if (*ptr == '.')
-                break;
 
-            int digit = (*ptr >= '0' && *ptr <= '9') ? (*ptr - '0') : ((*ptr & ~32) - 'A' + 10); // Convert to 0-15
+        for (char *ptr = end - 1; ptr >= str; --ptr) {
+            if (*ptr == '.') break;
+
+            int digit = (*ptr >= '0' && *ptr <= '9') ? (*ptr - '0') : ((*ptr & ~kIsLower) - 'A' + 10);  // Convert to 0-15
             digit += carry;
 
-            if (digit < 16)
-            {
-                *ptr  = (digit < 10) ? ('0' + digit) : (('A' | lower) + digit - 10); // Convert back to char
+            if (digit < 16) {
+                *ptr = (digit < 10) ? ('0' + digit) : (('A' | lower) + digit - 10);  // Convert back to char
                 carry = 0;
                 break;
-            }
-            else
-            {
-                *ptr  = '0'; // Rollover
+            } else {
+                *ptr = '0';  // Rollover
                 carry = 1;
             }
         }
@@ -662,15 +562,10 @@ static bool RoundFormattedDoubleHex(char *str, char lower)
     return carry;
 }
 
-static size_t RemoveTrailingZeros(char *str)
-{
-    size_t i  = 0;
+static size_t RemoveTrailingZeros(char *str) {
+    size_t i = 0;
     char *end = str + strlen(str) - 1;
-    while (end > str && *end == '0')
-    {
-        end--;
-        i++;
-    }
+    while (end > str && *end-- == '0') { ++i; }
     *(end + 1) = '\0';
     return i;
 }
@@ -679,55 +574,42 @@ static size_t RemoveTrailingZeros(char *str)
  *  Double formatting utilities
  */
 
-static double ipow(unsigned int base, int n)
-{
-    int i    = 1;
+static double ipow(unsigned int base, int n) {
+    int i = 1;
     double p = 1.0, m;
 
-    if (n < 0)
-    {
+    if (n < 0) {
         n = -n;
         m = 1.0 / base;
-    }
-    else
-    {
+    } else {
         m = base;
     }
 
-    for (; i <= n; i++)
-    {
+    for (; i <= n; i++) {
         p *= m;
     }
 
     return p;
 }
 
-static int ilog(double num, unsigned int base)
-{
+static int ilog(double num, unsigned int base) {
     int res = 0;
 
-    if (num == 0.0)
-    {
+    if (num == 0.0) {
         return 0;
     }
 
-    if (num < 0)
-    {
+    if (num < 0) {
         num *= -1;
     }
 
-    if (num < 1)
-    {
-        while (num < 1)
-        {
+    if (num < 1) {
+        while (num < 1) {
             num *= base;
             res--;
         }
-    }
-    else
-    {
-        while (num >= base)
-        {
+    } else {
+        while (num >= base) {
             num /= base;
             res++;
         }
@@ -736,56 +618,57 @@ static int ilog(double num, unsigned int base)
     return res;
 }
 
-FAST_CALL static bool IsNegative(double num)
-{
+FAST_CALL static bool IsNegative(double num) {
     auto intdbl = reinterpret_cast<uint64_t *>(&num);
     return (*intdbl & (1ULL << 63)) != 0;
 }
 
-FAST_CALL static bool IsSubnormal(double num)
-{
-    auto intdbl         = reinterpret_cast<uint64_t *>(&num);
+FAST_CALL static bool IsSubnormal(double num) {
+    auto intdbl = reinterpret_cast<uint64_t *>(&num);
     const auto exponent = static_cast<short>(*intdbl >> 52 & 0x7FF);
-    const auto mantisa  = *intdbl & (-1ULL >> 12);
-    return exponent == 0 && mantisa != 0;
+    const auto mantisa = *intdbl & (-1ULL >> 12);
+    return (exponent == 0 && mantisa != 0);
 }
 
 /**
  *  Integer formatting utilities
  */
 
-static char *FormatHex(uintmax_t num, char *str, int lower, bool prefix, int precision, bool zeroPadding, int width)
-{
+static char *FormatHex(uintmax_t num, char *str, int lower, bool prefix, int precision, bool zeroPadding, int width) {
     int i = 0;
 
-    if (num == 0)
-    {
-        if (precision == -1)
+    if (num == 0) {
+        if (precision == -1) {
             str[i++] = '0';
-        else
-        {
-            for (int j = 0; j < precision; ++j) str[i++] = '0';
+        } else {
+            for (int j = 0; j < precision; ++j) {
+                str[i++] = '0';
+            }
         }
         str[i] = '\0';
 
         return str;
     }
 
-    for (; num; num >>= 4) str[i++] = "0123456789ABCDEF"[num & 15] | lower;
-
-    if (zeroPadding)
-    {
-        int zeros = 0;
-        if (precision != -1)
-            zeros = precision - i;
-        else
-            zeros = width - i - ((prefix) ? 2 : 0);
-
-        for (int j = 0; j < zeros; ++j) str[i++] = '0';
+    for (; num; num >>= 4) {
+        str[i++] = "0123456789ABCDEF"[num & 15] | lower;
     }
 
-    if (prefix)
-    {
+    if (zeroPadding) {
+        int zeros = 0;
+
+        if (precision != -1) {
+            zeros = precision - i;
+        } else {
+            zeros = width - i - ((prefix) ? 2 : 0);
+        }
+
+        for (int j = 0; j < zeros; ++j) {
+            str[i++] = '0';
+        }
+    }
+
+    if (prefix) {
         str[i++] = 'X' | lower;
         str[i++] = '0';
     }
@@ -797,38 +680,41 @@ static char *FormatHex(uintmax_t num, char *str, int lower, bool prefix, int pre
     return str;
 }
 
-static char *FormatOct(uintmax_t num, char *str, bool prefix, int precision, bool zeroPadding, int width)
-{
+static char *FormatOct(uintmax_t num, char *str, bool prefix, int precision, bool zeroPadding, int width) {
     int i = 0;
 
-    if (num == 0)
-    {
-        if (precision == -1)
+    if (num == 0) {
+        if (precision == -1) {
             str[i++] = '0';
-        else
-        {
-            for (int j = 0; j < precision; ++j) str[i++] = '0';
+        } else {
+            for (int j = 0; j < precision; ++j) {
+                str[i++] = '0';
+            }
         }
         str[i] = '\0';
 
         return str;
     }
 
-    for (; num; num >>= 3) str[i++] = '0' + (num & 7);
-
-    if (zeroPadding)
-    {
-        int zeros = 0;
-        if (precision != -1)
-            zeros = precision - i - ((prefix) ? 1 : 0);
-        else
-            zeros = width - i - ((prefix) ? 1 : 0);
-
-        for (int j = 0; j < zeros; ++j) str[i++] = '0';
+    for (; num; num >>= 3) {
+        str[i++] = '0' + (num & 7);
     }
 
-    if (prefix)
-    {
+    if (zeroPadding) {
+        int zeros = 0;
+
+        if (precision != -1) {
+            zeros = precision - i - ((prefix) ? 1 : 0);
+        } else {
+            zeros = width - i - ((prefix) ? 1 : 0);
+        }
+
+        for (int j = 0; j < zeros; ++j) {
+            str[i++] = '0';
+        }
+    }
+
+    if (prefix) {
         str[i++] = '0';
     }
 
@@ -839,19 +725,19 @@ static char *FormatOct(uintmax_t num, char *str, bool prefix, int precision, boo
     return str;
 }
 
-static char *FormatUInt(uintmax_t num, char *str)
-{
+static char *FormatUInt(uintmax_t num, char *str) {
     int i = 0;
 
-    if (num == 0)
-    {
+    if (num == 0) {
         str[i++] = '0';
-        str[i]   = '\0';
+        str[i] = '\0';
 
         return str;
     }
 
-    for (; num; num /= 10) str[i++] = '0' + num % 10;
+    for (; num; num /= 10) {
+        str[i++] = '0' + num % 10;
+    }
 
     str[i] = '\0';
 
@@ -865,59 +751,46 @@ static char *FormatUInt(uintmax_t num, char *str)
  */
 
 template <bool scientific>
-static char *FormatDouble(
-    double num, char *str, unsigned int precision, char lower, bool trailZeros, bool hashForm, bool significantDigits
-)
-{
-    size_t i                = 0;
-    int exp                 = 0; // Exponent
-    int subnormalCorrection = 0;
-    bool foundNonZero       = false;
-    size_t significantCount = 0;
-
-    if (significantDigits && precision == 0)
+static char *FormatDouble(double num, char *str, unsigned int precision, char lower, bool trailZeros, bool hashForm, bool significantDigits) {
+    if (significantDigits && precision == 0) {
         precision = 1;
-
-    // Normalize
-    if (scientific)
-    {
-        if (IsSubnormal(num))
-        {
-            subnormalCorrection = -(ilog(num, 10) + 308);
-            num *= ipow(10, subnormalCorrection);
-            exp = -308;
-        }
-        else
-            exp = ilog(num, 10);
-
-        if (exp < 0)
-            num *= ipow(10, -exp);
-        else
-            num /= ipow(10, exp);
     }
 
+    // Normalize
+    int exponent = 0;
+    int subnormalCorrection = 0;
+    if (scientific) {
+        if (IsSubnormal(num)) {
+            subnormalCorrection = -(ilog(num, 10) + 308);
+            num *= ipow(10, subnormalCorrection);
+            exponent = -308;
+        } else {
+            exponent = ilog(num, 10);
+        }
+
+        if (exponent < 0) {
+            num *= ipow(10, -exponent);
+        } else {
+            num /= ipow(10, exponent);
+        }
+    }
+
+    size_t i = 0;
     double integralPart;
     double fractionalPart = modf(num, &integralPart);
 
-    if (scientific)
-    {
-        int digit = static_cast<char>((modf(num / 10, &integralPart) + INTEGRAL_PRECISION) * 10);
-        str[i++]  = '0' + digit;
-    }
-    else
-    {
-        if (integralPart == 0.0)
-        {
+    if (scientific) {
+        int digit = static_cast<char>((modf(num / 10, &integralPart) + kIntegralPrecision) * 10);
+        str[i++] = '0' + digit;
+    } else {
+        if (integralPart == 0.0) {
             str[i++] = '0';
-        }
-        else
-        {
-            for (num = integralPart; num != 0.0;)
-            {
+        } else {
+            for (num = integralPart; num != 0.0;) {
                 num /= 10;
-                int digit = static_cast<char>((modf(num, &integralPart) + INTEGRAL_PRECISION) * 10);
-                str[i++]  = '0' + digit;
-                num       = integralPart;
+                int digit = static_cast<char>((modf(num, &integralPart) + kIntegralPrecision) * 10);
+                str[i++] = '0' + digit;
+                num = integralPart;
             }
         }
     }
@@ -926,12 +799,11 @@ static char *FormatDouble(
     if (!scientific)
         ReverseString(str, i);
 
-    if (significantDigits)
-    {
-        for (size_t j = 0; j < i; ++j)
-        {
-            if (str[j] != '0' || foundNonZero)
-            {
+    bool foundNonZero = false;
+    size_t significantCount = 0;
+    if (significantDigits) {
+        for (size_t j = 0; j < i; ++j) {
+            if (str[j] != '0' || foundNonZero) {
                 foundNonZero = true;
                 if (++significantCount == precision)
                     break;
@@ -940,171 +812,165 @@ static char *FormatDouble(
     }
 
     // Add decimal point
-    if (precision > 0 || hashForm)
-    {
+    if (precision > 0 || hashForm) {
         str[i++] = '.';
     }
 
     // Fractional part
-    for (size_t j = 0;; ++j)
-    {
-        char digit = static_cast<char>((fractionalPart + FACTORIAL_PRECISION) * 10);
-        if (digit < 0 || digit > 9)
-            break; // Underflow
-        str[i++]       = '0' + digit;
+    for (size_t j = 0;; ++j) {
+        char digit =
+            static_cast<char>((fractionalPart + kFactorialPrecision) * 10);
+        if (digit < 0 || digit > 9) {
+            break;  // Underflow
+        }
+        str[i++] = '0' + digit;
         fractionalPart = (fractionalPart * 10) - static_cast<double>(digit);
 
-        if (significantDigits)
-        {
-            if (digit != 0 || foundNonZero)
-            {
+        if (significantDigits) {
+            if (digit != 0 || foundNonZero) {
                 foundNonZero = true;
-                if (++significantCount == precision + 1)
+                if (++significantCount == precision + 1) {
                     break;
-            }
-            else if (num == 0.0 && j >= precision - 1)
+                }
+            } else if (num == 0.0 && j >= precision - 1) {
                 break;
-        }
-        else if (j >= precision)
+            }
+        } else if (j >= precision) {
             break;
+        }
     }
     str[i] = '\0';
 
-    int carry = RoundFormattedDoubleDecimal(str, scientific);
+    const int carry = RoundFormattedDoubleDecimal(str, scientific);
+    exponent += carry;
     i--;
 
     // Remove trailing zeros
-    if (trailZeros)
-    {
+    if (trailZeros) {
         size_t count = 0;
-        if (!hashForm || str[i - 2] == '.')
+        if (!hashForm || str[i - 2] == '.') {
             count = RemoveTrailingZeros(str);
+        }
         i -= count;
 
-        if ((count == precision && !hashForm) || (!hashForm && str[i - 1] == '.'))
+        if ((count == precision && !hashForm) ||
+            (!hashForm && str[i - 1] == '.')) {
             i--;
+        }
     }
 
-    if (carry)
-        exp++;
 
-    if (scientific)
-    {
+    if (scientific) {
         str[i++] = 'E' | lower;
 
-        if (exp < 0)
-        {
-            exp *= -1;
+        if (exponent < 0) {
+            exponent *= -1;
             str[i++] = '-';
-        }
-        else
-        {
+        } else {
             str[i++] = '+';
         }
 
-        if (exp < 10)
+        if (exponent < 10) {
             str[i++] = '0';
+        }
 
-        FormatUInt(exp + subnormalCorrection, str + i);
+        FormatUInt(exponent + subnormalCorrection, str + i);
 
         return str;
-    }
-    else
-    {
+    } else {
         str[i] = '\0';
 
         return str;
     }
 }
 
-static char *FormatDoubleHex(
-    double num, char *str, int precision, char lower, bool trailZeros, bool hashForm, bool zeroPadding, int width
-)
-{
+static char *FormatDoubleHex(double num, char *str, int precision, char lower, bool trailZeros, bool hashForm, bool zeroPadding, int width) {
     size_t i = 0;
-    int exp  = ilog(num, 2); // Exponent
-
-    // TODO: Is it possible to remove this buffer?
-    char temp[BUFFER_SIZE];
 
     // Add prefix
     str[i++] = '0';
     str[i++] = 'X' | lower;
 
-    if (num == 0.0)
-    {
+    if (num == 0.0) {
         str[i++] = '0';
-        if (hashForm || precision != -1)
+
+        if (hashForm || precision != -1) {
             str[i++] = '.';
-        while (precision-- > 0) str[i++] = '0';
+        }
+
+        while (precision-- > 0) {
+            str[i++] = '0';
+        }
+
         str[i++] = 'P' | lower;
         str[i++] = '+';
         str[i++] = '0';
-        str[i]   = '\0';
+        str[i] = '\0';
 
         return str;
     }
 
-    precision = precision != -1 ? precision : DOUBLE_HEX_PRECISION_DIG;
+    // TODO: Is it possible to remove this buffer?
+    char temp[kBufferSize];
+    precision = precision != -1 ? precision : kDoubleHexPrecisionDigits;
 
-    i         = 0;
+    i = 0;
     temp[i++] = '1';
 
     // Add decimal point
-    if (precision > 0 || hashForm)
+    if (precision > 0 || hashForm) {
         temp[i++] = '.';
+    }
 
-    const size_t frac = i;
+    int exponent = ilog(num, 2);
 
     // Normalize
-    if (exp < 0.0)
-        num *= ipow(2, -exp);
-    else
-        num /= ipow(2, exp);
+    if (exponent < 0.0) {
+        num *= ipow(2, -exponent);
+    } else {
+        num /= ipow(2, exponent);
+    }
 
     // Fractional part
+    const size_t fracIdx = i;
     double integralPart;
     double fractionalPart = modf(num, &integralPart);
-    for (int j = 0; j < precision + 1; ++j)
-    {
+    for (int j = 0; j < precision + 1; ++j) {
         fractionalPart = modf(fractionalPart * 16, &integralPart);
-        temp[i++]      = "0123456789ABCDEF"[static_cast<char>(integralPart) & 15] | lower;
+        temp[i++] = "0123456789ABCDEF"[static_cast<char>(integralPart) & 15] | lower;
     }
     temp[i] = '\0';
 
-    bool carry = RoundFormattedDoubleHex(temp + frac, lower);
+    const int carry = RoundFormattedDoubleHex(temp + fracIdx, lower);
+    exponent += carry;
     --i;
 
-    if (trailZeros)
-    {
+    if (trailZeros) {
         size_t count = RemoveTrailingZeros(temp);
         i -= count;
 
-        if (static_cast<int>(count) == precision && !hashForm)
-            i--;
+        if (static_cast<int>(count) == precision && !hashForm) {
+            --i;
+        }
     }
-
-    if (carry)
-        exp++;
 
     temp[i++] = 'P' | lower;
 
-    if (exp >= 0)
-    {
+    if (exponent >= 0) {
         temp[i++] = '+';
-    }
-    else
-    {
-        exp *= -1;
+    } else {
+        exponent *= -1;
         temp[i++] = '-';
     }
 
-    int len = strlen(FormatUInt(exp, temp + i));
+    const size_t len = strlen(FormatUInt(exponent, temp + i));
 
     // Add zero padding
     {
         size_t j;
-        for (j = 2; zeroPadding && j < width - i - len; ++j) str[j] = '0';
+        for (j = 2; zeroPadding && j < width - i - len; ++j) {
+            str[j] = '0';
+        }
 
         strcpy(str + j, temp);
     }

--- a/alkos/libc/math/math.cpp
+++ b/alkos/libc/math/math.cpp
@@ -49,7 +49,7 @@ bool isinf(double num)
     return ((*intdbl >> 52 & 0x7FF) == 0x7FF) && ((*intdbl & (-1ULL >> 12)) == 0);
 }
 
-double abs(double num)
+double fabs(double num)
 {
     auto intdbl = reinterpret_cast<uint64_t *>(&num);
     *intdbl &= ~(1ULL << 63);

--- a/alkos/libc/math/math.cpp
+++ b/alkos/libc/math/math.cpp
@@ -2,21 +2,18 @@
 
 #include <stdint.h>
 
-double modf(double num, double *integralPart)
-{
-    auto intdbl         = reinterpret_cast<uint64_t *>(&num);
+double modf(double num, double *integralPart) {
+    auto intdbl = reinterpret_cast<uint64_t *>(&num);
     const auto exponent = static_cast<short>((*intdbl >> 52 & 0x7FF) - 1023);
 
     // No integral part
-    if (exponent < 0)
-    {
+    if (exponent < 0) {
         *integralPart = 0.0;
         return num;
     }
 
     // No fractional part (Over 2^52 the representable numbers are exactly the integers)
-    if (exponent >= 52)
-    {
+    if (exponent >= 52) {
         *integralPart = num;
         return 0.0;
     }
@@ -25,32 +22,28 @@ double modf(double num, double *integralPart)
     const uint64_t mask = -1ULL >> 12 >> exponent;
 
     // No fractional part
-    if ((*intdbl & mask) == 0)
-    {
+    if ((*intdbl & mask) == 0) {
         *integralPart = num;
         return 0.0;
     }
 
-    uint64_t tmp  = *intdbl & ~mask;
+    uint64_t tmp = *intdbl & ~mask;
     *integralPart = *reinterpret_cast<double *>(&tmp);
 
     return num - *integralPart;
 }
 
-bool isnan(double num)
-{
+bool isnan(double num) {
     auto intdbl = reinterpret_cast<uint64_t *>(&num);
     return ((*intdbl >> 52 & 0x7FF) == 0x7FF) && ((*intdbl & (-1ULL >> 12)) != 0);
 }
 
-bool isinf(double num)
-{
+bool isinf(double num) {
     auto intdbl = reinterpret_cast<uint64_t *>(&num);
     return ((*intdbl >> 52 & 0x7FF) == 0x7FF) && ((*intdbl & (-1ULL >> 12)) == 0);
 }
 
-double fabs(double num)
-{
+double fabs(double num) {
     auto intdbl = reinterpret_cast<uint64_t *>(&num);
     *intdbl &= ~(1ULL << 63);
     return num;

--- a/alkos/libc/math/math.cpp
+++ b/alkos/libc/math/math.cpp
@@ -1,0 +1,57 @@
+#include "math.h"
+
+#include <stdint.h>
+
+double modf(double num, double *integralPart)
+{
+    auto intdbl         = reinterpret_cast<uint64_t *>(&num);
+    const auto exponent = static_cast<short>((*intdbl >> 52 & 0x7FF) - 1023);
+
+    // No integral part
+    if (exponent < 0)
+    {
+        *integralPart = 0.0;
+        return num;
+    }
+
+    // No fractional part (Over 2^52 the representable numbers are exactly the integers)
+    if (exponent >= 52)
+    {
+        *integralPart = num;
+        return 0.0;
+    }
+
+    // Mantissa mask
+    const uint64_t mask = -1ULL >> 12 >> exponent;
+
+    // No fractional part
+    if ((*intdbl & mask) == 0)
+    {
+        *integralPart = num;
+        return 0.0;
+    }
+
+    uint64_t tmp   = *intdbl & ~mask;
+    *integralPart = *reinterpret_cast<double *>(&tmp);
+
+    return num - *integralPart;
+}
+
+bool isnan(double num)
+{
+    auto intdbl = reinterpret_cast<uint64_t *>(&num);
+    return ((*intdbl >> 52 & 0x7FF) == 0x7FF) && ((*intdbl & (-1ULL >> 12)) != 0);
+}
+
+bool isinf(double num)
+{
+    auto intdbl = reinterpret_cast<uint64_t *>(&num);
+    return ((*intdbl >> 52 & 0x7FF) == 0x7FF) && ((*intdbl & (-1ULL >> 12)) == 0);
+}
+
+double abs(double num)
+{
+    auto intdbl = reinterpret_cast<uint64_t *>(&num);
+    *intdbl &= ~(1ULL << 63);
+    return num;
+}

--- a/alkos/libc/math/math.cpp
+++ b/alkos/libc/math/math.cpp
@@ -31,7 +31,7 @@ double modf(double num, double *integralPart)
         return 0.0;
     }
 
-    uint64_t tmp   = *intdbl & ~mask;
+    uint64_t tmp  = *intdbl & ~mask;
     *integralPart = *reinterpret_cast<double *>(&tmp);
 
     return num - *integralPart;

--- a/alkos/libc/string/string.cpp
+++ b/alkos/libc/string/string.cpp
@@ -18,7 +18,7 @@ char *strncpy(char *dest, const char *src, size_t n)
 {
     size_t i  = 0;
     char *tmp = dest;
-    while (i != n && ((*tmp++ = *src++))) i++;
+    while (i != n && (*tmp++ = *src++)) i++;
     for (; i < n; ++i) *tmp++ = '\0';
     return dest;
 }
@@ -43,12 +43,13 @@ int strncmp(const char *str1, const char *str2, size_t n)
 
 char *strcat(char *dest, const char *src)
 {
-    size_t i = 0, j = 0;
+    size_t i = 0;
     char *tmp = dest;
     tmp += strlen(dest);
-    while (src[j])
+    while (src[i])
     {
-        tmp[i++] = src[j++];
+        tmp[i] = src[i];
+        i++;
     }
     tmp[i] = '\0';
     return dest;
@@ -56,40 +57,41 @@ char *strcat(char *dest, const char *src)
 
 char *strncat(char *dest, const char *src, size_t n)
 {
-    size_t i = 0, j = 0;
+    size_t i = 0;
     char *tmp = dest;
     tmp += strlen(dest);
-    while (src[j] && j < n)
+    while (src[i] && i < n)
     {
-        tmp[i++] = src[j++];
+        tmp[i] = src[i];
+        i++;
     }
     tmp[i] = '\0';
     return dest;
 }
 
-char *strchr(const char *s, int c)
+char *strchr(const char *str, int c)
 {
-    while (*s)
+    while (*str)
     {
-        if (*s == c)
+        if (*str == c)
         {
-            return const_cast<char *>(s);
+            return const_cast<char *>(str);
         }
-        s++;
+        str++;
     }
     return nullptr;
 }
 
-char *strrchr(const char *s, int c)
+char *strrchr(const char *str, int c)
 {
     const char *last = nullptr;
-    while (*s)
+    while (*str)
     {
-        if (*s == c)
+        if (*str == c)
         {
-            last = s;
+            last = str;
         }
-        s++;
+        str++;
     }
     return const_cast<char *>(last);
 }

--- a/alkos/libc/string/string.cpp
+++ b/alkos/libc/string/string.cpp
@@ -1,0 +1,95 @@
+#include "string.h"
+
+size_t strlen(const char *str)
+{
+    const char *s;
+    for (s = str; *s; ++s);
+    return s - str;
+}
+
+char *strcpy(char *dest, const char *src)
+{
+    char *tmp = dest;
+    while ((*tmp++ = *src++));
+    return dest;
+}
+
+char *strncpy(char *dest, const char *src, size_t n)
+{
+    size_t i  = 0;
+    char *tmp = dest;
+    while (i != n && ((*tmp++ = *src++))) i++;
+    for (; i < n; ++i) *tmp++ = '\0';
+    return dest;
+}
+
+int strcmp(const char *str1, const char *str2)
+{
+    size_t i       = 0;
+    const auto *s1 = reinterpret_cast<const unsigned char *>(str1);
+    const auto *s2 = reinterpret_cast<const unsigned char *>(str2);
+    while (s1[i] == s2[i] && s1[i]) i++;
+    return s1[i] - s2[i];
+}
+
+int strncmp(const char *str1, const char *str2, size_t n)
+{
+    size_t i       = 0;
+    const auto *s1 = reinterpret_cast<const unsigned char *>(str1);
+    const auto *s2 = reinterpret_cast<const unsigned char *>(str2);
+    while (s1[i] == s2[i] && s1[i] && i < n - 1) i++;
+    return s1[i] - s2[i];
+}
+
+char *strcat(char *dest, const char *src)
+{
+    size_t i = 0, j = 0;
+    char *tmp = dest;
+    tmp += strlen(dest);
+    while (src[j])
+    {
+        tmp[i++] = src[j++];
+    }
+    tmp[i] = '\0';
+    return dest;
+}
+
+char *strncat(char *dest, const char *src, size_t n)
+{
+    size_t i = 0, j = 0;
+    char *tmp = dest;
+    tmp += strlen(dest);
+    while (src[j] && j < n)
+    {
+        tmp[i++] = src[j++];
+    }
+    tmp[i] = '\0';
+    return dest;
+}
+
+char *strchr(const char *s, int c)
+{
+    while (*s)
+    {
+        if (*s == c)
+        {
+            return const_cast<char *>(s);
+        }
+        s++;
+    }
+    return nullptr;
+}
+
+char *strrchr(const char *s, int c)
+{
+    const char *last = nullptr;
+    while (*s)
+    {
+        if (*s == c)
+        {
+            last = s;
+        }
+        s++;
+    }
+    return const_cast<char *>(last);
+}

--- a/alkos/libc/string/string.cpp
+++ b/alkos/libc/string/string.cpp
@@ -1,97 +1,82 @@
 #include "string.h"
 
-size_t strlen(const char *str)
-{
+size_t strlen(const char *str) {
     const char *s;
-    for (s = str; *s; ++s);
+    for (s = str; *s; ++s) continue;
     return s - str;
 }
 
-char *strcpy(char *dest, const char *src)
-{
+char *strcpy(char *dest, const char *src) {
     char *tmp = dest;
-    while ((*tmp++ = *src++));
+    while ((*tmp++ = *src++)) continue;
     return dest;
 }
 
-char *strncpy(char *dest, const char *src, size_t n)
-{
-    size_t i  = 0;
-    char *tmp = dest;
-    while (i != n && (*tmp++ = *src++)) i++;
-    for (; i < n; ++i) *tmp++ = '\0';
-    return dest;
-}
-
-int strcmp(const char *str1, const char *str2)
-{
-    size_t i       = 0;
-    const auto *s1 = reinterpret_cast<const unsigned char *>(str1);
-    const auto *s2 = reinterpret_cast<const unsigned char *>(str2);
-    while (s1[i] == s2[i] && s1[i]) i++;
-    return s1[i] - s2[i];
-}
-
-int strncmp(const char *str1, const char *str2, size_t n)
-{
-    size_t i       = 0;
-    const auto *s1 = reinterpret_cast<const unsigned char *>(str1);
-    const auto *s2 = reinterpret_cast<const unsigned char *>(str2);
-    while (s1[i] == s2[i] && s1[i] && i < n - 1) i++;
-    return s1[i] - s2[i];
-}
-
-char *strcat(char *dest, const char *src)
-{
+char *strncpy(char *dest, const char *src, size_t n) {
     size_t i = 0;
     char *tmp = dest;
+    for (; i != n && (*tmp++ = *src++); ++i) continue;
+    for (; i < n; ++i) { *tmp++ = '\0'; }
+    return dest;
+}
+
+int strcmp(const char *str1, const char *str2) {
+    size_t i = 0;
+    const auto *s1 = reinterpret_cast<const unsigned char *>(str1);
+    const auto *s2 = reinterpret_cast<const unsigned char *>(str2);
+    while (s1[i] == s2[i] && s1[i]) { ++i; }
+    return s1[i] - s2[i];
+}
+
+int strncmp(const char *str1, const char *str2, size_t n) {
+    const auto *s1 = reinterpret_cast<const unsigned char *>(str1);
+    const auto *s2 = reinterpret_cast<const unsigned char *>(str2);
+    size_t i = 0;
+    while (s1[i] == s2[i] && s1[i] && i < n - 1) { ++i; }
+    return s1[i] - s2[i];
+}
+
+char *strcat(char *dest, const char *src) {
+    char *tmp = dest;
     tmp += strlen(dest);
-    while (src[i])
-    {
+    size_t i = 0;
+    while (src[i]) {
         tmp[i] = src[i];
-        i++;
+        ++i;
     }
     tmp[i] = '\0';
     return dest;
 }
 
-char *strncat(char *dest, const char *src, size_t n)
-{
-    size_t i = 0;
+char *strncat(char *dest, const char *src, size_t n) {
     char *tmp = dest;
     tmp += strlen(dest);
-    while (src[i] && i < n)
-    {
+    size_t i = 0;
+    while (src[i] && i < n) {
         tmp[i] = src[i];
-        i++;
+        ++i;
     }
     tmp[i] = '\0';
     return dest;
 }
 
-char *strchr(const char *str, int c)
-{
-    while (*str)
-    {
-        if (*str == c)
-        {
+char *strchr(const char *str, int c) {
+    while (*str) {
+        if (*str == c) {
             return const_cast<char *>(str);
         }
-        str++;
+        ++str;
     }
     return nullptr;
 }
 
-char *strrchr(const char *str, int c)
-{
+char *strrchr(const char *str, int c) {
     const char *last = nullptr;
-    while (*str)
-    {
-        if (*str == c)
-        {
+    while (*str) {
+        if (*str == c) {
             last = str;
         }
-        str++;
+        ++str;
     }
     return const_cast<char *>(last);
 }

--- a/alkos/libc/string/strlen.cpp
+++ b/alkos/libc/string/strlen.cpp
@@ -1,8 +1,0 @@
-#include <stddef.h>
-
-size_t strlen(const char *str)
-{
-    size_t len = 0;
-    while (str[len]) len++;
-    return len;
-}

--- a/alkos/toolchains/x86_64-flags.cmake
+++ b/alkos/toolchains/x86_64-flags.cmake
@@ -1,6 +1,6 @@
 # Architecture specific flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -ffreestanding")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -ffreestanding -fno-exceptions -fno-rtti")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -ffreestanding -mstackrealign")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -ffreestanding -fno-exceptions -fno-rtti -mstackrealign")
 set(CMAKE_ASM_NASM_FLAGS "${CMAKE_ASM_NASM_FLAGS} -f elf64")
 
 # Debug or Release flags

--- a/scripts/install/run_alkos.bash
+++ b/scripts/install/run_alkos.bash
@@ -8,9 +8,8 @@ source "${RUN_ALKOS_SCRIPT_SOURCE_DIR}/scripts/utils/helpers.bash"
 source "${RUN_ALKOS_SCRIPT_SOURCE_DIR}/scripts/utils/pretty_print.bash"
 
 RUN_ALKOS_SCRIPT_QEMU_COMMAND="qemu-system-x86_64"
-RUN_ALKOS_SCRIPT_QEMU_ARGS="-serial stdio"
 RUN_ALKOS_SCRIPT_GDB_ARGS="-s -S"
-RUN_ALKOS_SCRIPT_QEMU_ARGS="-serial stdio -enable-kvm -cpu host"
+RUN_ALKOS_SCRIPT_QEMU_ARGS="-serial stdio -enable-kvm -cpu host -display default,show-cursor=on"
 help() {
   echo "${RUN_ALKOS_SCRIPT_PATH} [alkos_iso_path] [--run | -r] [--verbose | -v]"
   echo "Where:"


### PR DESCRIPTION
Things done in this PR:

### Implementation of mathematical functions:
* [`alkos/libc/math/math.cpp`](diffhunk://#diff-8e7e866d7c61fec482ce4274a768bdb7a321a6bea8a06da22fad778b38c3f819R1-R57): Implemented mathematical functions including `modf`, `isnan`, `isinf`, and `abs`.

### Implementation of string functions:
* [`alkos/libc/string/string.cpp`](diffhunk://#diff-e75e25fbe5e02a6c436073185b5c5d7180cf7f33eec4eedc61fc9616c6d047f7R1-R95): Implemented string functions including `strlen`, `strcpy`, `strncpy`, `strcmp`, `strncmp`, `strcat`, `strncat`, `strchr`, and `strrchr`.

### Implementation of formatted string output function
* [`alkos/libc/io/snprintf.cpp`](diffhunk://#diff-9260856c9f7ec3e5a4d683f9f1984af1ab74fd1fd19e37ef55acfbb2dffdb4e5): Implemented writing formatted data to a string, with a size limit.

### Build and script configuration updates:
* [`alkos/toolchains/x86_64-flags.cmake`](diffhunk://#diff-5f5bbeb1c23de2a86a69344ba4869c11f650978ad68ac5aa66c2ff6710bd990eL2-R3): Added `-mstackrealign` flag to C and C++ compiler flags for aligning stack to 16 bytes.
* [`scripts/install/run_alkos.bash`](diffhunk://#diff-a9f2cb53e4061982dbabb8f6fe5e15a478658094328d590893bd7341a9034537L11-R12): Updated QEMU arguments to include `-display default,show-cursor=on` for better display handling.