### PR TITLE
Added verbose asserts mechanism

### DIFF
--- a/alkos/kernel/arch/x86_64/abi/panic.cpp
+++ b/alkos/kernel/arch/x86_64/abi/panic.cpp
@@ -5,7 +5,7 @@
 #include <terminal.hpp>
 #include <test_module/test_module.hpp>
 
-extern "C" void KernelPanic(const char *msg)
+extern "C" NO_RET void KernelPanic(const char *msg)
 {
     TerminalWriteError("[ KERNEL PANIC ]\n");
     TerminalWriteError(msg);

--- a/alkos/kernel/arch/x86_64/drivers/vga/vga.cpp
+++ b/alkos/kernel/arch/x86_64/drivers/vga/vga.cpp
@@ -68,7 +68,7 @@ static uint16_t *g_TerminalBuffer;  ///< Pointer to VGA memory buffer (0xB8000)
  * Combines foreground and background colors into a single byte
  * where the background color is in the high nibble.
  */
-static FORCE_INLINE uint8_t VgaEntryColor(const VgaColor fg, const VgaColor bg)
+static FORCE_INLINE_F uint8_t VgaEntryColor(const VgaColor fg, const VgaColor bg)
 {
     return fg | bg << 4;
 }
@@ -83,7 +83,7 @@ static FORCE_INLINE uint8_t VgaEntryColor(const VgaColor fg, const VgaColor bg)
  * Creates a 16-bit VGA character entry with the character in the low byte
  * and the color attribute in the high byte.
  */
-static FORCE_INLINE uint16_t VgaEntry(const unsigned char uc, const uint8_t color)
+static FORCE_INLINE_F uint16_t VgaEntry(const unsigned char uc, const uint8_t color)
 {
     return static_cast<uint16_t>(uc) | static_cast<uint16_t>(color) << 8;
 }

--- a/alkos/kernel/arch/x86_64/include/arch_utils.hpp
+++ b/alkos/kernel/arch/x86_64/include/arch_utils.hpp
@@ -43,7 +43,7 @@ FAST_CALL void HaltCpu() { __asm__ volatile("hlt"); }
  * Enters an infinite loop that continuously halts the CPU.
  * Allows interrupts to wake the CPU.
  */
-FAST_CALL void OsHang()
+FAST_CALL NO_RET void OsHang()
 {
     while (true) {
         HaltCpu();
@@ -77,7 +77,7 @@ FAST_CALL void InvokeInterrupt(const u8 idx) { __asm__ volatile("int %0" : : "N"
  * Writes shutdown command to QEMU exit port and halts CPU.
  * Only works when running under QEMU.
  */
-FAST_CALL void QemuShutdown()
+FAST_CALL NO_RET void QemuShutdown()
 {
     outw(0x604, 0x2000);
     OsHang();

--- a/alkos/kernel/include/defines.hpp
+++ b/alkos/kernel/include/defines.hpp
@@ -12,13 +12,16 @@
 #define NO_RET __attribute__((noreturn))
 
 /* Force the compiler to always inline the function */
-#define FORCE_INLINE inline __attribute__((always_inline))
+#define FORCE_INLINE_F inline __attribute__((always_inline))
+
+/* Force the compiler to always inline the lambda */
+#define FORCE_INLINE_L __attribute__((always_inline))
 
 /* Declare a function as a static inline wrapper */
-#define WRAP_CALL static FORCE_INLINE
+#define WRAP_CALL static FORCE_INLINE_F
 
 /* Require a function to be inlined for performance reasons */
-#define FAST_CALL static FORCE_INLINE
+#define FAST_CALL static FORCE_INLINE_F
 
 // ------------------------------------
 // Macro to constexpr conversions
@@ -41,6 +44,12 @@ static constexpr bool kIsAlkosTestBuild = true;
 #else
 static constexpr bool kIsAlkosTestBuild = false;
 #endif  // __ALKOS_TESTS_BUILD__
+
+#ifdef NDEBUG
+static constexpr bool kIsDebugBuild = false;
+#else
+static constexpr bool kIsDebugBuild = true;
+#endif  // NDEBUG
 
 // ------------------------------
 // Useful macros

--- a/alkos/kernel/include/kernel_assert.hpp
+++ b/alkos/kernel/include/kernel_assert.hpp
@@ -3,7 +3,9 @@
 
 #include <defines.hpp>
 #include <panic.hpp>
+#include <string.h>
 #include <todo.hpp>
+#include <types.hpp>
 
 // ------------------------------
 // Int type asserts
@@ -15,18 +17,12 @@
     );
 
 /* c-like debug only assert */
-#ifdef NDEBUG
-
-#define ASSERT(expr)
-
-#else
-
-#define ASSERT(expr)       \
-    if (!(expr)) {         \
-        FAIL_KERNEL(expr); \
+#define ASSERT(expr)             \
+    if constexpr(kIsDebugBuild){ \
+        if (!(expr)) {           \
+            FAIL_KERNEL(expr);   \
+        }                        \
     }
-
-#endif  // NDEBUG
 
 /* Works also in release build */
 #define R_ASSERT(expr)     \
@@ -34,64 +30,469 @@
         FAIL_KERNEL(expr); \
     }
 
+// -------------------------------------
+// TODO: temporary print mechanism
+// -------------------------------------
+
+/* This print should be replaced by some type driven print mechanism */
+TODO_BY_THE_END_OF_MILESTONE1
+static constexpr size_t kObjToHexBuffSize = 512;
+
+template<typename ObjT>
+void VerboseAssertDumpObjToHex(const ObjT &obj, char *buffer, size_t buffer_size) {
+    ASSERT(buffer != nullptr);
+    ASSERT(buffer_size > 0);
+
+    const auto obj_bytes = reinterpret_cast<const u8 *>(&obj);
+    for (size_t i = 0; i < sizeof(ObjT); ++i) {
+        const int bytes_written = snprintf(buffer, buffer_size, "%02X ", obj_bytes[i]);
+        ASSERT(bytes_written < buffer_size && "VerboseAssertDumpObjToHex buffer fully used!");
+
+        buffer += bytes_written;
+        buffer_size -= bytes_written;
+    }
+}
+
+/* TODO: temporary overload for char* */
+FAST_CALL void VerboseAssertDumpObjToHex(const char *obj, char *buffer, const size_t buffer_size) {
+    strncpy(buffer, obj, buffer_size);
+}
+
+// ------------------------------
+// Base for verbose asserts
+// ------------------------------
+
+static constexpr size_t kFailMsgBuffSize = 2048;
+static constexpr size_t kFullAssertMsgBuffSize = 512 + kFailMsgBuffSize;
+
+FAST_CALL void VerboseAssertDump(const char *msg, const char *file, const char *line) {
+    char full_assert_msg[kFullAssertMsgBuffSize];
+    const int bytes_written = snprintf(full_assert_msg, kFullAssertMsgBuffSize,
+                                       "Assertion failed at file: %s and line: %s\n%s\n", file, line, msg);
+    ASSERT(bytes_written < kFullAssertMsgBuffSize && "VerboseAssertDump buffer fully used!");
+
+    KernelPanic(full_assert_msg);
+}
+
+template<class ExpectedT, class ValueT, class CheckerT, class MsgGetterT>
+FAST_CALL void VerboseAssertTwoArgBase(const ExpectedT &expected,
+                                       const ValueT &value,
+                                       CheckerT checker,
+                                       MsgGetterT msg_getter,
+                                       const char *expected_str,
+                                       const char *value_str,
+                                       const char *file,
+                                       const char *line) {
+    if (!checker(expected, value)) {
+        char fail_msg[kFailMsgBuffSize];
+        char e_obj[kObjToHexBuffSize];
+        char v_obj[kObjToHexBuffSize];
+
+        VerboseAssertDumpObjToHex(expected, e_obj, kObjToHexBuffSize);
+        VerboseAssertDumpObjToHex(value, v_obj, kObjToHexBuffSize);
+
+        msg_getter(fail_msg, kFailMsgBuffSize, expected_str, value_str, e_obj, v_obj);
+        VerboseAssertDump(fail_msg, file, line);
+    }
+}
+
+template<class ValueT, class CheckerT, class MsgGetterT>
+FAST_CALL void VerboseAssertOneArgBase(const ValueT &value,
+                                       CheckerT checker,
+                                       MsgGetterT msg_getter,
+                                       const char *value_str,
+                                       const char *file,
+                                       const char *line) {
+    if (!checker(value)) {
+        char fail_msg[kFailMsgBuffSize];
+        char v_obj[kObjToHexBuffSize];
+
+        VerboseAssertDumpObjToHex(value, v_obj, kObjToHexBuffSize);
+
+        msg_getter(fail_msg, kFailMsgBuffSize, value_str, v_obj);
+        VerboseAssertDump(fail_msg, file, line);
+    }
+}
+
+// ------------------------------
+// EQ Assert base
+// ------------------------------
+
+template<class ExpectedT, class ValueT>
+FAST_CALL void VerboseAssertEq(const ExpectedT &expected,
+                               const ValueT &value,
+                               const char *expected_str,
+                               const char *value_str,
+                               const char *file,
+                               const char *line) {
+    VerboseAssertTwoArgBase(
+        expected, value,
+        [](ExpectedT &e, ValueT &v) { return e == v; },
+        [](char *msg, const size_t size, const char *e_str, const char *v_str,
+           const char *e_dump, const char *v_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (EQ)!\n"
+                                               "Actual value does not match the expected value.\n"
+                                               "Expected value: %s\n"
+                                               "Which is: %s\n"
+                                               "Actual value: %s\n"
+                                               "Which is: %s\n", e_str, e_dump, v_str, v_dump);
+            ASSERT(bytes_written < size && "VerboseAssertEq buffer fully used!");
+        },
+        expected_str, value_str, file, line
+    );
+}
+
+// ------------------------------
+// NEQ Assert base
+// ------------------------------
+
+template<class ExpectedT, class ValueT>
+FAST_CALL void VerboseAssertNeq(const ExpectedT &expected,
+                                const ValueT &value,
+                                const char *expected_str,
+                                const char *value_str,
+                                const char *file,
+                                const char *line) {
+    VerboseAssertTwoArgBase(
+        expected, value,
+        [](ExpectedT &e, ValueT &v) { return e != v; },
+        [](char *msg, const size_t size, const char *e_str, const char *v_str,
+           const char *e_dump, const char *v_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (NEQ)!\n"
+                                               "Actual value does matches the expected value, when it shouldn't.\n"
+                                               "Expected value: %s\n"
+                                               "Which is: %s\n"
+                                               "Actual value: %s\n"
+                                               "Which is: %s\n", e_str, e_dump, v_str, v_dump);
+            ASSERT(bytes_written < size && "VerboseAssertNeq buffer fully used!");
+        },
+        expected_str, value_str, file, line
+    );
+}
+
+// ------------------------------
+// TRUE assert base
+// ------------------------------
+
+template<class ValueT>
+void VerboseAssertTrue(const ValueT &value,
+                       const char *value_str,
+                       const char *file,
+                       const char *line) {
+    VerboseAssertOneArgBase(
+        value,
+        [](ValueT &v) { return v == true; },
+        [](char *msg, const size_t size, const char *v_str, const char *v_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (TRUE)!\n"
+                                               "Given value was supposed to be equal to true!\n"
+                                               "Expected value: true\n"
+                                               "Actual value: %s\n"
+                                               "Which is: %s\n", v_str, v_dump);
+            ASSERT(bytes_written < size && "VerboseAssertTrue buffer fully used!");
+        },
+        value_str, file, line
+    );
+}
+
+// ------------------------------
+// FALSE assert base
+// ------------------------------
+
+template<class ValueT>
+void VerboseAssertFalse(const ValueT &value,
+                        const char *value_str,
+                        const char *file,
+                        const char *line) {
+    VerboseAssertOneArgBase(
+        value,
+        [](ValueT &v) { return v == false; },
+        [](char *msg, const size_t size, const char *v_str, const char *v_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (FALSE)!\n"
+                                               "Given value was supposed to be equal to false!\n"
+                                               "Expected value: True\n"
+                                               "Actual value: %s\n"
+                                               "Which is: %s\n", v_str, v_dump);
+            ASSERT(bytes_written < size && "VerboseAssertFalse buffer fully used!");
+        },
+        value_str, file, line
+    );
+}
+
+// ------------------------------
+// NOT_NULL assert base
+// ------------------------------
+
+template<class ValueT>
+void VerboseAssertNotNull(const ValueT &value,
+                          const char *value_str,
+                          const char *file,
+                          const char *line) {
+    VerboseAssertOneArgBase(
+        value,
+        [](ValueT &v) { return v != nullptr; },
+        [](char *msg, const size_t size, const char *v_str, const char *v_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (NOT_NULL)!\n"
+                                               "Given value was supposed to be not null!\n"
+                                               "Actual value: %s\n"
+                                               "Which is: %s\n", v_str, v_dump);
+            ASSERT(bytes_written < size && "VerboseAssertNotNull buffer fully used!");
+        },
+        value_str, file, line
+    );
+}
+
+// ------------------------------
+// NULL assert base
+// ------------------------------
+
+template<class ValueT>
+void VerboseAssertNull(const ValueT &value,
+                       const char *value_str,
+                       const char *file,
+                       const char *line) {
+    VerboseAssertOneArgBase(
+        value,
+        [](ValueT &v) { return v == nullptr; },
+        [](char *msg, const size_t size, const char *v_str, const char *v_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (NULL)!\n"
+                                               "Given value was supposed to be null!\n"
+                                               "Actual value: %s\n"
+                                               "Which is: %s\n", v_str, v_dump);
+            ASSERT(bytes_written < size && "VerboseAssertNull buffer fully used!");
+        },
+        value_str, file, line
+    );
+}
+
+// ------------------------------
+// LT (Less Than) assert base
+// ------------------------------
+
+template<class Val1T, class Val2T>
+void VerboseAssertLt(const Val1T &val1,
+                     const Val2T &val2,
+                     const char *val1_str,
+                     const char *val2_str,
+                     const char *file,
+                     const char *line) {
+    VerboseAssertTwoArgBase(
+        val1, val2,
+        [](Val1T &v1, Val2T &v2) { return v1 < v2; },
+        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+           const char *v1_dump, const char *v2_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (LT)!\n"
+                                               "First value should be less than second value!\n"
+                                               "First value: %s\n"
+                                               "Which is: %s\n"
+                                               "Second value: %s\n"
+                                               "Which is: %s\n", v1_str, v1_dump, v2_str, v2_dump);
+            ASSERT(bytes_written < size && "VerboseAssertLt buffer fully used!");
+        },
+        val1_str, val2_str, file, line
+    );
+}
+
+// ------------------------------
+// LE (Less Than or Equal) assert base
+// ------------------------------
+
+template<class Val1T, class Val2T>
+void VerboseAssertLe(const Val1T &val1,
+                     const Val2T &val2,
+                     const char *val1_str,
+                     const char *val2_str,
+                     const char *file,
+                     const char *line) {
+    VerboseAssertTwoArgBase(
+        val1, val2,
+        [](Val1T &v1, Val2T &v2) { return v1 <= v2; },
+        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+           const char *v1_dump, const char *v2_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (LE)!\n"
+                                               "First value should be less than or equal to second value!\n"
+                                               "First value: %s\n"
+                                               "Which is: %s\n"
+                                               "Second value: %s\n"
+                                               "Which is: %s\n", v1_str, v1_dump, v2_str, v2_dump);
+            ASSERT(bytes_written < size && "VerboseAssertLe buffer fully used!");
+        },
+        val1_str, val2_str, file, line
+    );
+}
+
+// ------------------------------
+// GT (Greater Than) assert base
+// ------------------------------
+
+template<class Val1T, class Val2T>
+void VerboseAssertGt(const Val1T &val1,
+                     const Val2T &val2,
+                     const char *val1_str,
+                     const char *val2_str,
+                     const char *file,
+                     const char *line) {
+    VerboseAssertTwoArgBase(
+        val1, val2,
+        [](Val1T &v1, Val2T &v2) { return v1 > v2; },
+        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+           const char *v1_dump, const char *v2_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (GT)!\n"
+                                               "First value should be greater than second value!\n"
+                                               "First value: %s\n"
+                                               "Which is: %s\n"
+                                               "Second value: %s\n"
+                                               "Which is: %s\n", v1_str, v1_dump, v2_str, v2_dump);
+            ASSERT(bytes_written < size && "VerboseAssertGt buffer fully used!");
+        },
+        val1_str, val2_str, file, line
+    );
+}
+
+// ------------------------------
+// GE (Greater Than or Equal) assert base
+// ------------------------------
+
+template<class Val1T, class Val2T>
+void VerboseAssertGe(const Val1T &val1,
+                     const Val2T &val2,
+                     const char *val1_str,
+                     const char *val2_str,
+                     const char *file,
+                     const char *line) {
+    VerboseAssertTwoArgBase(
+        val1, val2,
+        [](Val1T &v1, Val2T &v2) { return v1 >= v2; },
+        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+           const char *v1_dump, const char *v2_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (GE)!\n"
+                                               "First value should be greater than or equal to second value!\n"
+                                               "First value: %s\n"
+                                               "Which is: %s\n"
+                                               "Second value: %s\n"
+                                               "Which is: %s\n", v1_str, v1_dump, v2_str, v2_dump);
+            ASSERT(bytes_written < size && "VerboseAssertGe buffer fully used!");
+        },
+        val1_str, val2_str, file, line
+    );
+}
+
+// ------------------------------
+// String Equal assert base
+// ------------------------------
+
+template<class Val1T, class Val2T>
+void VerboseAssertStrEq(const Val1T &val1,
+                        const Val2T &val2,
+                        const char *val1_str,
+                        const char *val2_str,
+                        const char *file,
+                        const char *line) {
+    VerboseAssertTwoArgBase(
+        val1, val2,
+        [](Val1T &v1, Val2T &v2) { return strcmp(v1, v2) == 0; },
+        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+           const char *v1_dump, const char *v2_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (STREQ)!\n"
+                                               "Strings should be equal!\n"
+                                               "First string: %s\n"
+                                               "Which is: %s\n"
+                                               "Second string: %s\n"
+                                               "Which is: %s\n", v1_str, v1_dump, v2_str, v2_dump);
+            ASSERT(bytes_written < size && "VerboseAssertStrEq buffer fully used!");
+        },
+        val1_str, val2_str, file, line
+    );
+}
+
+// ------------------------------
+// String Not Equal assert base
+// ------------------------------
+
+template<class Val1T, class Val2T>
+void VerboseAssertStrNeq(const Val1T &val1,
+                         const Val2T &val2,
+                         const char *val1_str,
+                         const char *val2_str,
+                         const char *file,
+                         const char *line) {
+    VerboseAssertTwoArgBase(
+        val1, val2,
+        [](Val1T &v1, Val2T &v2) { return strcmp(v1, v2) != 0; },
+        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+           const char *v1_dump, const char *v2_dump) {
+            const int bytes_written = snprintf(msg, size,
+                                               "Assertion failed (STRNEQ)!\n"
+                                               "Strings should not be equal!\n"
+                                               "First string: %s\n"
+                                               "Which is: %s\n"
+                                               "Second string: %s\n"
+                                               "Which is: %s\n", v1_str, v1_dump, v2_str, v2_dump);
+            ASSERT(bytes_written < size && "VerboseAssertStrNeq buffer fully used!");
+        },
+        val1_str, val2_str, file, line
+    );
+}
+
+
+// ------------------------------
+// Macro wrappers
+// ------------------------------
+
+#define BASE_ASSERT_EQ(is_active, expected, value) if constexpr (is_active) VerboseAssertEq(expected, value, TOSTRING(expected), TOSTRING(value), __FILE__, __LINE__)
+#define BASE_ASSERT_NEQ(is_active, expected, value) if constexpr (is_active) VerboseAssertNeq(expected, value, TOSTRING(expected), TOSTRING(value), __FILE__, __LINE__)
+#define BASE_ASSERT_TRUE(is_active, value) if constexpr (is_active) VerboseAssertTrue(value, TOSTRING(value), __FILE__, __LINE__)
+#define BASE_ASSERT_FALSE(is_active, value) if constexpr (is_active) VerboseAssertFalse(value, TOSTRING(value), __FILE__, __LINE__)
+#define BASE_ASSERT_NOT_NULL(is_active, value) if constexpr (is_active) VerboseAssertNotNull(value, TOSTRING(value), __FILE__, __LINE__)
+#define BASE_ASSERT_NULL(is_active, value) if constexpr (is_active) VerboseAssertNull(value, TOSTRING(value), __FILE__, __LINE__)
+#define BASE_ASSERT_LT(is_active, val1, val2) if constexpr (is_active) VerboseAssertLt(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
+#define BASE_ASSERT_LE(is_active, val1, val2) if constexpr (is_active) VerboseAssertLe(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
+#define BASE_ASSERT_GT(is_active, val1, val2) if constexpr (is_active) VerboseAssertGt(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
+#define BASE_ASSERT_GE(is_active, val1, val2) if constexpr (is_active) VerboseAssertGe(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
+#define BASE_ASSERT_STREQ(is_active, val1, val2) if constexpr (is_active) VerboseAssertStrEq(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
+#define BASE_ASSERT_STRNEQ(is_active, val1, val2) if constexpr (is_active) VerboseAssertStrNeq(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
+
 // ------------------------------
 // Verbose asserts
 // ------------------------------
 
-/**
- * Verbose assertions to compare expected and actual values.
- *
- * @param expected The expected value.
- * @param value The actual value.
- *
- * TODO: Add descriptive prints to these macros when snprintf or equivalent
- * functionality becomes available. This will improve the clarity of assertion
- * failures by providing detailed context.
- *
- * Additionally, consider defining the following macros for greater versatility:
- * - ASSERT_LT(expected, value): Checks if `expected` is less than `value`.
- * - ASSERT_GT(expected, value): Checks if `expected` is greater than `value`.
- * - ASSERT_LE(expected, value): Checks if `expected` is less than or equal to `value`.
- * - ASSERT_GE(expected, value): Checks if `expected` is greater than or equal to `value`.
- */
+/* usual C-style asserts */
+#define ASSERT_EQ(expected, value) BASE_ASSERT_EQ(kIsDebugBuild, expected, value)
+#define ASSERT_NEQ(expected, value) BASE_ASSERT_NEQ(kIsDebugBuild, expected, value)
+#define ASSERT_TRUE(value) BASE_ASSERT_TRUE(kIsDebugBuild, value)
+#define ASSERT_FALSE(value) BASE_ASSERT_FALSE(kIsDebugBuild, value)
+#define ASSERT_NOT_NULL(value) BASE_ASSERT_NOT_NULL(kIsDebugBuild, value)
+#define ASSERT_NULL(value) BASE_ASSERT_NULL(kIsDebugBuild, value)
+#define ASSERT_LT(val1, val2) BASE_ASSERT_LT(kIsDebugBuild, val1, val2)
+#define ASSERT_LE(val1, val2) BASE_ASSERT_LE(kIsDebugBuild, val1, val2)
+#define ASSERT_GT(val1, val2) BASE_ASSERT_GT(kIsDebugBuild, val1, val2)
+#define ASSERT_GE(val1, val2) BASE_ASSERT_GE(kIsDebugBuild, val1, val2)
+#define ASSERT_STREQ(val1, val2) BASE_ASSERT_STREQ(kIsDebugBuild, val1, val2)
+#define ASSERT_STRNEQ(val1, val2) BASE_ASSERT_STRNEQ(kIsDebugBuild, val1, val2)
 
-TODO_BY_THE_END_OF_MILESTONE0
-TODO_WHEN_SNPRINTF_EXISTS
-TODO_WHEN_VMEM_WORKS
 
-#define R_ASSERT_EQ(expected, value)        \
-    {                                       \
-        if (expected != value) {            \
-            FAIL_KERNEL(expected == value); \
-        }                                   \
-    }
-
-#define R_ASSERT_NEQ(expected, value)       \
-    {                                       \
-        if (expected == value) {            \
-            FAIL_KERNEL(expected != value); \
-        }                                   \
-    }
-
-#define R_ASSERT_TRUE(value)            \
-    {                                   \
-        if (value != true) {            \
-            FAIL_KERNEL(value == true); \
-        }                               \
-    };
-
-#define R_ASSERT_NOT_NULL(value)           \
-    {                                      \
-        if (value == nullptr) {            \
-            FAIL_KERNEL(value != nullptr); \
-        }                                  \
-    }
-
-#define R_ASSERT_NULL(value)               \
-    {                                      \
-        if (value != nullptr) {            \
-            FAIL_KERNEL(value == nullptr); \
-        }                                  \
-    }
+/* release build asserts */
+#define R_ASSERT_EQ(expected, value) BASE_ASSERT_EQ(true, expected, value)
+#define R_ASSERT_NEQ(expected, value) BASE_ASSERT_NEQ(true, expected, value)
+#define R_ASSERT_TRUE(value) BASE_ASSERT_TRUE(true, value)
+#define R_ASSERT_FALSE(value) BASE_ASSERT_FALSE(true, value)
+#define R_ASSERT_NOT_NULL(value) BASE_ASSERT_NOT_NULL(true, value)
+#define R_ASSERT_NULL(value) BASE_ASSERT_NULL(true, value)
+#define R_ASSERT_LT(val1, val2) BASE_ASSERT_LT(true, val1, val2)
+#define R_ASSERT_LE(val1, val2) BASE_ASSERT_LE(true, val1, val2)
+#define R_ASSERT_GT(val1, val2) BASE_ASSERT_GT(true, val1, val2)
+#define R_ASSERT_GE(val1, val2) BASE_ASSERT_GE(true, val1, val2)
+#define R_ASSERT_STREQ(val1, val2) BASE_ASSERT_STREQ(true, val1, val2)
+#define R_ASSERT_STRNEQ(val1, val2) BASE_ASSERT_STRNEQ(true, val1, val2)
 
 #endif  // KERNEL_INCLUDE_ASSERT_HPP_

--- a/alkos/kernel/include/kernel_assert.hpp
+++ b/alkos/kernel/include/kernel_assert.hpp
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <todo.hpp>
 #include <types.hpp>
+#include <stdio.h>
 
 // ------------------------------
 // Int type asserts
@@ -46,7 +47,7 @@ void VerboseAssertDumpObjToHex(const ObjT &obj, char *buffer, size_t buffer_size
     const auto obj_bytes = reinterpret_cast<const u8 *>(&obj);
     for (size_t i = 0; i < sizeof(ObjT); ++i) {
         const int bytes_written = snprintf(buffer, buffer_size, "%02X ", obj_bytes[i]);
-        ASSERT(bytes_written < buffer_size && "VerboseAssertDumpObjToHex buffer fully used!");
+        ASSERT(bytes_written < static_cast<int>(buffer_size) && "VerboseAssertDumpObjToHex buffer fully used!");
 
         buffer += bytes_written;
         buffer_size -= bytes_written;
@@ -69,7 +70,7 @@ FAST_CALL void VerboseAssertDump(const char *msg, const char *file, const char *
     char full_assert_msg[kFullAssertMsgBuffSize];
     const int bytes_written = snprintf(full_assert_msg, kFullAssertMsgBuffSize,
                                        "Assertion failed at file: %s and line: %s\n%s\n", file, line, msg);
-    ASSERT(bytes_written < kFullAssertMsgBuffSize && "VerboseAssertDump buffer fully used!");
+    ASSERT(bytes_written < static_cast<int>(kFullAssertMsgBuffSize) && "VerboseAssertDump buffer fully used!");
 
     KernelPanic(full_assert_msg);
 }
@@ -127,8 +128,8 @@ FAST_CALL void VerboseAssertEq(const ExpectedT &expected,
                                const char *line) {
     VerboseAssertTwoArgBase(
         expected, value,
-        [](ExpectedT &e, ValueT &v) { return e == v; },
-        [](char *msg, const size_t size, const char *e_str, const char *v_str,
+        [](const ExpectedT &e, const ValueT &v) { return e == v; },
+        [](char *msg, const int size, const char *e_str, const char *v_str,
            const char *e_dump, const char *v_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (EQ)!\n"
@@ -156,8 +157,8 @@ FAST_CALL void VerboseAssertNeq(const ExpectedT &expected,
                                 const char *line) {
     VerboseAssertTwoArgBase(
         expected, value,
-        [](ExpectedT &e, ValueT &v) { return e != v; },
-        [](char *msg, const size_t size, const char *e_str, const char *v_str,
+        [](const ExpectedT &e, const ValueT &v) { return e != v; },
+        [](char *msg, const int size, const char *e_str, const char *v_str,
            const char *e_dump, const char *v_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (NEQ)!\n"
@@ -183,8 +184,8 @@ void VerboseAssertTrue(const ValueT &value,
                        const char *line) {
     VerboseAssertOneArgBase(
         value,
-        [](ValueT &v) { return v == true; },
-        [](char *msg, const size_t size, const char *v_str, const char *v_dump) {
+        [](const ValueT &v) { return v == true; },
+        [](char *msg, const int size, const char *v_str, const char *v_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (TRUE)!\n"
                                                "Given value was supposed to be equal to true!\n"
@@ -208,8 +209,8 @@ void VerboseAssertFalse(const ValueT &value,
                         const char *line) {
     VerboseAssertOneArgBase(
         value,
-        [](ValueT &v) { return v == false; },
-        [](char *msg, const size_t size, const char *v_str, const char *v_dump) {
+        [](const ValueT &v) { return v == false; },
+        [](char *msg, const int size, const char *v_str, const char *v_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (FALSE)!\n"
                                                "Given value was supposed to be equal to false!\n"
@@ -233,8 +234,8 @@ void VerboseAssertNotNull(const ValueT &value,
                           const char *line) {
     VerboseAssertOneArgBase(
         value,
-        [](ValueT &v) { return v != nullptr; },
-        [](char *msg, const size_t size, const char *v_str, const char *v_dump) {
+        [](const ValueT &v) { return v != nullptr; },
+        [](char *msg, const int size, const char *v_str, const char *v_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (NOT_NULL)!\n"
                                                "Given value was supposed to be not null!\n"
@@ -257,8 +258,8 @@ void VerboseAssertNull(const ValueT &value,
                        const char *line) {
     VerboseAssertOneArgBase(
         value,
-        [](ValueT &v) { return v == nullptr; },
-        [](char *msg, const size_t size, const char *v_str, const char *v_dump) {
+        [](const ValueT &v) { return v == nullptr; },
+        [](char *msg, const int size, const char *v_str, const char *v_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (NULL)!\n"
                                                "Given value was supposed to be null!\n"
@@ -283,8 +284,8 @@ void VerboseAssertLt(const Val1T &val1,
                      const char *line) {
     VerboseAssertTwoArgBase(
         val1, val2,
-        [](Val1T &v1, Val2T &v2) { return v1 < v2; },
-        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+        [](const Val1T &v1, const Val2T &v2) { return v1 < v2; },
+        [](char *msg, const int size, const char *v1_str, const char *v2_str,
            const char *v1_dump, const char *v2_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (LT)!\n"
@@ -312,8 +313,8 @@ void VerboseAssertLe(const Val1T &val1,
                      const char *line) {
     VerboseAssertTwoArgBase(
         val1, val2,
-        [](Val1T &v1, Val2T &v2) { return v1 <= v2; },
-        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+        [](const Val1T &v1, const Val2T &v2) { return v1 <= v2; },
+        [](char *msg, const int size, const char *v1_str, const char *v2_str,
            const char *v1_dump, const char *v2_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (LE)!\n"
@@ -341,8 +342,8 @@ void VerboseAssertGt(const Val1T &val1,
                      const char *line) {
     VerboseAssertTwoArgBase(
         val1, val2,
-        [](Val1T &v1, Val2T &v2) { return v1 > v2; },
-        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+        [](const Val1T &v1, const Val2T &v2) { return v1 > v2; },
+        [](char *msg, const int size, const char *v1_str, const char *v2_str,
            const char *v1_dump, const char *v2_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (GT)!\n"
@@ -370,8 +371,8 @@ void VerboseAssertGe(const Val1T &val1,
                      const char *line) {
     VerboseAssertTwoArgBase(
         val1, val2,
-        [](Val1T &v1, Val2T &v2) { return v1 >= v2; },
-        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+        [](const Val1T &v1, const Val2T &v2) { return v1 >= v2; },
+        [](char *msg, const int size, const char *v1_str, const char *v2_str,
            const char *v1_dump, const char *v2_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (GE)!\n"
@@ -390,17 +391,16 @@ void VerboseAssertGe(const Val1T &val1,
 // String Equal assert base
 // ------------------------------
 
-template<class Val1T, class Val2T>
-void VerboseAssertStrEq(const Val1T &val1,
-                        const Val2T &val2,
-                        const char *val1_str,
-                        const char *val2_str,
-                        const char *file,
-                        const char *line) {
+inline void VerboseAssertStrEq(const char *val1,
+                               const char *val2,
+                               const char *val1_str,
+                               const char *val2_str,
+                               const char *file,
+                               const char *line) {
     VerboseAssertTwoArgBase(
         val1, val2,
-        [](Val1T &v1, Val2T &v2) { return strcmp(v1, v2) == 0; },
-        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+        [](const char *v1, const char *v2) { return strcmp(v1, v2) == 0; },
+        [](char *msg, const int size, const char *v1_str, const char *v2_str,
            const char *v1_dump, const char *v2_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (STREQ)!\n"
@@ -419,17 +419,16 @@ void VerboseAssertStrEq(const Val1T &val1,
 // String Not Equal assert base
 // ------------------------------
 
-template<class Val1T, class Val2T>
-void VerboseAssertStrNeq(const Val1T &val1,
-                         const Val2T &val2,
-                         const char *val1_str,
-                         const char *val2_str,
-                         const char *file,
-                         const char *line) {
+inline void VerboseAssertStrNeq(const char *val1,
+                                const char *val2,
+                                const char *val1_str,
+                                const char *val2_str,
+                                const char *file,
+                                const char *line) {
     VerboseAssertTwoArgBase(
         val1, val2,
-        [](Val1T &v1, Val2T &v2) { return strcmp(v1, v2) != 0; },
-        [](char *msg, const size_t size, const char *v1_str, const char *v2_str,
+        [](const char *v1, const char *v2) { return strcmp(v1, v2) != 0; },
+        [](char *msg, const int size, const char *v1_str, const char *v2_str,
            const char *v1_dump, const char *v2_dump) {
             const int bytes_written = snprintf(msg, size,
                                                "Assertion failed (STRNEQ)!\n"
@@ -449,18 +448,19 @@ void VerboseAssertStrNeq(const Val1T &val1,
 // Macro wrappers
 // ------------------------------
 
-#define BASE_ASSERT_EQ(is_active, expected, value) if constexpr (is_active) VerboseAssertEq(expected, value, TOSTRING(expected), TOSTRING(value), __FILE__, __LINE__)
-#define BASE_ASSERT_NEQ(is_active, expected, value) if constexpr (is_active) VerboseAssertNeq(expected, value, TOSTRING(expected), TOSTRING(value), __FILE__, __LINE__)
-#define BASE_ASSERT_TRUE(is_active, value) if constexpr (is_active) VerboseAssertTrue(value, TOSTRING(value), __FILE__, __LINE__)
-#define BASE_ASSERT_FALSE(is_active, value) if constexpr (is_active) VerboseAssertFalse(value, TOSTRING(value), __FILE__, __LINE__)
-#define BASE_ASSERT_NOT_NULL(is_active, value) if constexpr (is_active) VerboseAssertNotNull(value, TOSTRING(value), __FILE__, __LINE__)
-#define BASE_ASSERT_NULL(is_active, value) if constexpr (is_active) VerboseAssertNull(value, TOSTRING(value), __FILE__, __LINE__)
-#define BASE_ASSERT_LT(is_active, val1, val2) if constexpr (is_active) VerboseAssertLt(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
-#define BASE_ASSERT_LE(is_active, val1, val2) if constexpr (is_active) VerboseAssertLe(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
-#define BASE_ASSERT_GT(is_active, val1, val2) if constexpr (is_active) VerboseAssertGt(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
-#define BASE_ASSERT_GE(is_active, val1, val2) if constexpr (is_active) VerboseAssertGe(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
-#define BASE_ASSERT_STREQ(is_active, val1, val2) if constexpr (is_active) VerboseAssertStrEq(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
-#define BASE_ASSERT_STRNEQ(is_active, val1, val2) if constexpr (is_active) VerboseAssertStrNeq(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, __LINE__)
+#define BASE_ASSERT_EQ(is_active, expected, value) if constexpr (is_active) VerboseAssertEq(expected, value, TOSTRING(expected), TOSTRING(value), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_NEQ(is_active, expected, value) if constexpr (is_active) VerboseAssertNeq(expected, value, TOSTRING(expected), TOSTRING(value), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_TRUE(is_active, value) if constexpr (is_active) VerboseAssertTrue(value, TOSTRING(value), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_FALSE(is_active, value) if constexpr (is_active) VerboseAssertFalse(value, TOSTRING(value), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_NOT_NULL(is_active, value) if constexpr (is_active) VerboseAssertNotNull(value, TOSTRING(value), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_NULL(is_active, value) if constexpr (is_active) VerboseAssertNull(value, TOSTRING(value), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_LT(is_active, val1, val2) if constexpr (is_active) VerboseAssertLt(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_LE(is_active, val1, val2) if constexpr (is_active) VerboseAssertLe(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_GT(is_active, val1, val2) if constexpr (is_active) VerboseAssertGt(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_GE(is_active, val1, val2) if constexpr (is_active) VerboseAssertGe(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_STREQ(is_active, val1, val2) if constexpr (is_active) VerboseAssertStrEq(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, TOSTRING(__LINE__))
+#define BASE_ASSERT_STRNEQ(is_active, val1, val2) if constexpr (is_active) VerboseAssertStrNeq(val1, val2, TOSTRING(val1), TOSTRING(val2), __FILE__, TOSTRING(__LINE__))
+
 
 // ------------------------------
 // Verbose asserts

--- a/alkos/kernel/test/asserts_tests.cpp
+++ b/alkos/kernel/test/asserts_tests.cpp
@@ -1,0 +1,170 @@
+#include <test_module/test.hpp>
+
+// ------------------------------
+// R_ASSERT_EQ Tests
+// ------------------------------
+
+TEST(RAssertEqPass) {
+    R_ASSERT_EQ(5, 5);
+    R_ASSERT_EQ(true, true);
+    R_ASSERT_EQ(nullptr, nullptr);
+}
+
+FAIL_TEST(RAssertEqFail) {
+    R_ASSERT_EQ(5, 10);
+}
+
+// ------------------------------
+// R_ASSERT_NEQ Tests
+// ------------------------------
+
+TEST(RAssertNeqPass) {
+    R_ASSERT_NEQ(5, 10);
+    R_ASSERT_NEQ(true, false);
+    int value = 5;
+    R_ASSERT_NEQ(&value, nullptr);
+}
+
+FAIL_TEST(RAssertNeqFail) {
+    R_ASSERT_NEQ(5, 5);
+}
+
+// ------------------------------
+// R_ASSERT_TRUE Tests
+// ------------------------------
+
+TEST(RAssertTruePass) {
+    R_ASSERT_TRUE(true);
+    R_ASSERT_TRUE(1 == 1);
+    R_ASSERT_TRUE(5 > 3);
+}
+
+FAIL_TEST(RAssertTrueFail) {
+    R_ASSERT_TRUE(false);
+}
+
+// ------------------------------
+// R_ASSERT_FALSE Tests
+// ------------------------------
+
+TEST(RAssertFalsePass) {
+    R_ASSERT_FALSE(false);
+    R_ASSERT_FALSE(1 == 2);
+    R_ASSERT_FALSE(5 < 3);
+}
+
+FAIL_TEST(RAssertFalseFail) {
+    R_ASSERT_FALSE(true);
+}
+
+// ------------------------------
+// R_ASSERT_NOT_NULL Tests
+// ------------------------------
+
+TEST(RAssertNotNullPass) {
+    int value = 5;
+    int *ptr = &value;
+    R_ASSERT_NOT_NULL(ptr);
+}
+
+FAIL_TEST(RAssertNotNullFail) {
+    int *ptr = nullptr;
+    R_ASSERT_NOT_NULL(ptr);
+}
+
+// ------------------------------
+// R_ASSERT_NULL Tests
+// ------------------------------
+
+TEST(RAssertNullPass) {
+    int *ptr = nullptr;
+    R_ASSERT_NULL(ptr);
+}
+
+FAIL_TEST(RAssertNullFail) {
+    int value = 5;
+    int *ptr = &value;
+    R_ASSERT_NULL(ptr);
+}
+
+// ------------------------------
+// R_ASSERT_LT Tests
+// ------------------------------
+
+TEST(RAssertLtPass) {
+    R_ASSERT_LT(5, 10);
+}
+
+FAIL_TEST(RAssertLtFail) {
+    R_ASSERT_LT(10, 5);
+}
+
+// ------------------------------
+// R_ASSERT_LE Tests
+// ------------------------------
+
+TEST(RAssertLePass) {
+    R_ASSERT_LE(5, 5);
+    R_ASSERT_LE(5, 10);
+}
+
+FAIL_TEST(RAssertLeFail) {
+    R_ASSERT_LE(10, 5);
+}
+
+// ------------------------------
+// R_ASSERT_GT Tests
+// ------------------------------
+
+TEST(RAssertGtPass) {
+    R_ASSERT_GT(10, 5);
+}
+
+FAIL_TEST(RAssertGtFail) {
+    R_ASSERT_GT(5, 10);
+}
+
+// ------------------------------
+// R_ASSERT_GE Tests
+// ------------------------------
+
+TEST(RAssertGePass) {
+    R_ASSERT_GE(5, 5);
+    R_ASSERT_GE(10, 5);
+}
+
+FAIL_TEST(RAssertGeFail) {
+    R_ASSERT_GE(5, 10);
+}
+
+// ------------------------------
+// R_ASSERT_STREQ Tests
+// ------------------------------
+
+TEST(RAssertStrEqPass) {
+    const char *str1 = "test";
+    const char *str2 = "test";
+    R_ASSERT_STREQ(str1, str2);
+}
+
+FAIL_TEST(RAssertStrEqFail) {
+    const char *str1 = "test1";
+    const char *str2 = "test2";
+    R_ASSERT_STREQ(str1, str2);
+}
+
+// ------------------------------
+// R_ASSERT_STRNEQ Tests
+// ------------------------------
+
+TEST(RAssertStrNeqPass) {
+    const char *str1 = "test1";
+    const char *str2 = "test2";
+    R_ASSERT_STRNEQ(str1, str2);
+}
+
+FAIL_TEST(RAssertStrNeqFail) {
+    const char *str1 = "test";
+    const char *str2 = "test";
+    R_ASSERT_STRNEQ(str1, str2);
+}


### PR DESCRIPTION
Things done in this PR:
- added classical gtest like asserts to the code,
- implemented temporary print mechanism,
- asserts implemented: `ASSERT_EQ`, `ASSERT_NEQ`, `ASSERT_TRUE`, `ASSERT_FALSE`, `ASSERT_NOT_NULL`, `ASSERT_NULL`, `ASSERT_LT`, `ASSERT_LE`, `ASSERT_GT`, `ASSERT_GE`, `ASSERT_STREQ`, `ASSERT_STRNEQ`
- added test for each macro,
- added `kIsDebugBuild` constant,
- added force inline macro for lambdas
- fixed NO_RET attributes for some functions