### PR TITLE
Updated install scripts to download toolchain for i386 and x86_64

### DIFF
--- a/scripts/actions/clean_build_dir.bash
+++ b/scripts/actions/clean_build_dir.bash
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+CLEAN_BUILD_SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+CLEAN_BUILD_SCRIPT_PATH="${CLEAN_BUILD_SCRIPT_DIR}/$(basename "$0")"
+CLEAN_BUILD_BUILD_DIR="${CLEAN_BUILD_SCRIPT_DIR}/../../build"
+
+source "${CLEAN_BUILD_SCRIPT_DIR}/../utils/pretty_print.bash"
+source "${CLEAN_BUILD_SCRIPT_DIR}/../utils/helpers.bash"
+
+help() {
+  echo "${CLEAN_BUILD_SCRIPT_PATH} [--verbose | -v]"
+  echo "Where:"
+  echo "--verbose | -v - flag to enable verbose output"
+}
+
+parse_args() {
+  CLEAN_BUILD_VERBOSE=false
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h|--help)
+        help
+        exit 0
+        ;;
+      -v|--verbose)
+        CLEAN_BUILD_VERBOSE=true
+        shift
+        ;;
+      *)
+        dump_error "Unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+process_args() {
+  if [[ "${CLEAN_BUILD_VERBOSE}" == "true" ]]; then
+    CLEAN_BUILD_VERBOSE_FLAG="--verbose"
+  else
+    CLEAN_BUILD_VERBOSE_FLAG=""
+  fi
+}
+
+main() {
+  # print all flags
+  for arg in "$@"; do
+    echo "arg: $arg"
+  done
+
+  parse_args "$@"
+  process_args
+
+  if [[ ! -d "${CLEAN_BUILD_BUILD_DIR}" ]]; then
+    pretty_info "Build directory does not exist"
+    exit 0
+  fi
+
+  pretty_info "Deleting config.cache"
+  if [[ "${CLEAN_BUILD_VERBOSE}" == "true" ]]; then
+    find ${CLEAN_BUILD_BUILD_DIR} -name "config.cache" -delete
+  else
+    find ${CLEAN_BUILD_BUILD_DIR} -name "config.cache" -delete &> /dev/null
+  fi
+  pretty_info "Running make distclean"
+  find "${CLEAN_BUILD_BUILD_DIR}" -type f \( -iname "Makefile" -o -iname "makefile" -o -iname "GNUmakefile" \) -printf '%h\n' | sort -u | while read -r dir; do
+    if [[ "${CLEAN_BUILD_VERBOSE}" == "true" ]]; then
+      (cd "$dir" && make distclean && make clean)
+    else
+      (cd "$dir" && make distclean && make clean) &> /dev/null
+    fi
+  done
+  pretty_success "${CLEAN_BUILD_BUILD_DIR} cleaned"
+}
+
+main "$@"

--- a/scripts/actions/install_toolchain.bash
+++ b/scripts/actions/install_toolchain.bash
@@ -1,0 +1,69 @@
+INSTALL_TOOLCHAIN_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+INSTALL_TOOLCHAIN_DEFAULT_ARCHES=("x86_64-elf" "i386-elf") # TODO: read from config?
+
+INSTALL_TOOLCHAIN_INSTALL_DIR="${INSTALL_TOOLCHAIN_DIR}/../../tools"
+INSTALL_TOOLCHAIN_BUILD_DIR="${INSTALL_TOOLCHAIN_DIR}/../../build"
+
+INSTALL_TOOLCHAIN_BUILD_SCRIPT_PATH="${INSTALL_TOOLCHAIN_DIR}/../env/build_cross_compile.bash"
+INSTALL_TOOLCHAIN_CLEAN_BUILD_SCRIPT_PATH="${INSTALL_TOOLCHAIN_DIR}/clean_build_dir.bash"
+
+source "${INSTALL_TOOLCHAIN_DIR}/../utils/pretty_print.bash"
+source "${INSTALL_TOOLCHAIN_DIR}/../utils/helpers.bash"
+
+help() {
+  echo "${INSTALL_TOOLCHAIN_SCRIPT_PATH} [--verbose | -v]"
+  echo "Where:"
+  echo "--verbose | -v - flag to enable verbose output"
+}
+
+parse_args() {
+  INSTALL_TOOLCHAIN_VERBOSE=false
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h|--help)
+        help
+        exit 0
+        ;;
+      -v|--verbose)
+        INSTALL_TOOLCHAIN_VERBOSE=true
+        shift
+        ;;
+      *)
+        dump_error "Unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+process_args() {
+  if [[ "${INSTALL_TOOLCHAIN_VERBOSE}" == "true" ]]; then
+    INSTALL_TOOLCHAIN_VERBOSE_FLAG="--verbose"
+  else
+    INSTALL_TOOLCHAIN_VERBOSE_FLAG=""
+  fi
+}
+
+main() {
+  parse_args "$@"
+  process_args
+
+  pretty_info "Installing cross-compile toolchain"
+  for arch in "${INSTALL_TOOLCHAIN_DEFAULT_ARCHES[@]}"; do
+    pretty_info "Installing for ${arch}"
+    base_runner "Failed to clean build directory" true "${INSTALL_TOOLCHAIN_CLEAN_BUILD_SCRIPT_PATH}" ${INSTALL_TOOLCHAIN_VERBOSE_FLAG}
+    # Spawn a subshell to run the build script (to avoid polluting the current shell)
+    (
+      base_runner "Failed to install cross-compile toolchain" true "${INSTALL_TOOLCHAIN_BUILD_SCRIPT_PATH}" --install \
+        toolchain "${INSTALL_TOOLCHAIN_VERBOSE_FLAG}"   \
+          -t "${INSTALL_TOOLCHAIN_INSTALL_DIR}/${arch}" \
+          -b "${INSTALL_TOOLCHAIN_BUILD_DIR}/${arch}"   \
+          -c "${arch}"
+
+      exit 0
+    ) 2>&1 || exit 1
+  done
+}
+
+main "$@"
+

--- a/scripts/alkos_cli.bash
+++ b/scripts/alkos_cli.bash
@@ -6,7 +6,7 @@ ALK_OS_CLI_SCRIPT_PATH="${ALK_OS_CLI_SCRIPT_DIR}/$(basename "$0")"
 ALK_OS_CLI_DEFAULT_TOOL_INSTALL_DIR="${ALK_OS_CLI_SCRIPT_DIR}/../tools"
 ALK_OS_CLI_DEFAULT_BUILD_DIR="${ALK_OS_CLI_SCRIPT_DIR}/../build"
 
-ALK_OS_CLI_INSTALL_TOOLCHAIN_PATH="${ALK_OS_CLI_SCRIPT_DIR}/env/build_cross_compile.bash"
+ALK_OS_CLI_INSTALL_TOOLCHAIN_PATH="${ALK_OS_CLI_SCRIPT_DIR}/actions/install_toolchain.bash"
 ALK_OS_CLI_BUILD_SCRIPT_PATH="${ALK_OS_CLI_SCRIPT_DIR}/install/build_alkos.bash"
 ALK_OS_CLI_INSTALL_DEPS_SCRIPT_PATH="${ALK_OS_CLI_SCRIPT_DIR}/env/install_deps_arch.bash"
 ALK_OS_CLI_QEMU_RUN_SCRIPT_PATH="${ALK_OS_CLI_SCRIPT_DIR}/install/run_alkos.bash"
@@ -97,14 +97,12 @@ main() {
   fi
 
   if [ $ALK_OS_CLI_INSTALL_TOOLCHAIN = true ] ; then
-    pretty_info "Installing cross-compile toolchain"
-    base_runner "Failed to install cross-compile toolchain" true "${ALK_OS_CLI_INSTALL_TOOLCHAIN_PATH}" --install \
-      toolchain ${ALK_OS_CLI_VERBOSE_FLAG} -t "${ALK_OS_CLI_DEFAULT_TOOL_INSTALL_DIR}" -b "${ALK_OS_CLI_DEFAULT_BUILD_DIR}"
+    base_runner "Failed to install cross-compile toolchain" true "${ALK_OS_CLI_INSTALL_TOOLCHAIN_PATH}" ${ALK_OS_CLI_VERBOSE_FLAG}
   fi
 
   if [ $ALK_OS_CLI_RUN = true ] ; then
-    base_runner "Failed to build AlkOS" "${ALK_OS_CLI_VERBOSE}" "${ALK_OS_CLI_BUILD_SCRIPT_PATH}" --run ${ALK_OS_CLI_VERBOSE_FLAG}
-    base_runner "Failed to run AlkOS in QEMU" "${ALK_OS_CLI_VERBOSE}" "${ALK_OS_CLI_QEMU_RUN_SCRIPT_PATH}" "${ALK_OS_CLI_ISO_PATH}" --run ${ALK_OS_CLI_VERBOSE_FLAG}
+    base_runner "Failed to build AlkOS" true "${ALK_OS_CLI_BUILD_SCRIPT_PATH}" --run ${ALK_OS_CLI_VERBOSE_FLAG}
+    base_runner "Failed to run AlkOS in QEMU" true "${ALK_OS_CLI_QEMU_RUN_SCRIPT_PATH}" "${ALK_OS_CLI_ISO_PATH}" --run ${ALK_OS_CLI_VERBOSE_FLAG}
   fi
 }
 

--- a/scripts/env/arch_packages.txt
+++ b/scripts/env/arch_packages.txt
@@ -4,7 +4,7 @@ libisoburn
 mtools
 base-devel
 gmp
-mpc
+libmpc
 mpfr
 base-devel
 wget

--- a/scripts/env/arch_packages.txt
+++ b/scripts/env/arch_packages.txt
@@ -4,7 +4,7 @@ libisoburn
 mtools
 base-devel
 gmp
-libmpc
+mpc
 mpfr
 base-devel
 wget

--- a/scripts/env/build_cross_compile.bash
+++ b/scripts/env/build_cross_compile.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CROSS_COMPILE_BUILD_SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 CROSS_COMPILE_BUILD_SCRIPT_PATH="${CROSS_COMPILE_BUILD_SCRIPT_DIR}/$(basename "$0")"
@@ -11,6 +11,7 @@ CROSS_COMPILE_BUILD_TARGET=x86_64-elf
 CROSS_COMPILE_BUILD_POSITIONAL_ARGS=()
 CROSS_COMPILE_BUILD_INSTALL_FOUND=false
 CROSS_COMPILE_BUILD_VERBOSE=false
+CROSS_COMPILE_USES_DEFAULT_TARGET=true
 
 PROC_COUNT=$(nproc --all)
 
@@ -18,11 +19,12 @@ source "${CROSS_COMPILE_BUILD_SCRIPT_DIR}/../utils/pretty_print.bash"
 source "${CROSS_COMPILE_BUILD_SCRIPT_DIR}/../utils/helpers.bash"
 
 help() {
-    echo "${CROSS_COMPILE_BUILD_SCRIPT_PATH} --install [--build_dir | -b <dir>] [--tool_dir | -t <dir>] [--verbose | -v]"
+    echo "${CROSS_COMPILE_BUILD_SCRIPT_PATH} --install [--build_dir | -b <dir>] [--tool_dir | -t <dir>] [--custom_target | -c <target>]"
     echo "Where:"
     echo "--install         | -i - required flag to start installation"
     echo "--build_dir <dir> | -b <dir> - provides directory <dir> to save all build files"
     echo "--tool_dir  <dir> | -t <dir> - directory where tooling should be saved"
+    echo "--custom_target   | -c - custom target to build cross-compiler for (default: x86_64-elf)"
     echo "--verbose         | -v - flag to enable verbose output"
 }
 
@@ -205,6 +207,12 @@ parse_args() {
                 CROSS_COMPILE_BUILD_VERBOSE=true
                 shift
                 ;;
+            -c|--custom_target)
+                CROSS_COMPILE_BUILD_TARGET="$2"
+                CROSS_COMPILE_USES_DEFAULT_TARGET=false
+                shift
+                shift
+                ;;
             -*)
                 dump_error "Unknown option $1"
                 ;;
@@ -229,6 +237,12 @@ process_args() {
 
     if [ -z "${CROSS_COMPILE_BUILD_BUILD_DIR}" ] ; then
         dump_error "--build_dir | -t flag with directory where save build files was not provided!"
+    fi
+
+    if [ $CROSS_COMPILE_USES_DEFAULT_TARGET = false ] ; then
+        pretty_info "Using custom target: ${CROSS_COMPILE_BUILD_TARGET}"
+    else
+        pretty_info "Using default target: ${CROSS_COMPILE_BUILD_TARGET}"
     fi
 }
 


### PR DESCRIPTION
In order to achieve #70  we require both the i386 toolchain and x86_64 toolchain.


New scripts:

* [`scripts/actions/clean_build_dir.bash`](diffhunk://#diff-8e3bd4ed1eccaced4f7c655e786b8beb7bc50cbc4d9dec5b312a430f1e0aa300R1-R74): Added a new script to clean the build directory
* [`scripts/actions/install_toolchain.bash`](diffhunk://#diff-4b4f83f52181c6aacd131f1f0e19bfef043f6f94ad3fc3ef44004e7499646920R1-R69): Added a new script to install the cross-compile toolchain with support for multiple architectures.

Updates to existing scripts:

* [`scripts/alkos_cli.bash`](diffhunk://#diff-d6fe9a3e8f641a3f60a80deb12392cfa03d1c044e26fff8f2ad85d8fe5471b73L9-R9): Updated to use the new toolchain installation script
* [`scripts/env/build_cross_compile.bash`](diffhunk://#diff-ffc85218e152db2f3b304662092ffd89c58caf496080efbdff5bec7a0391e7c3L1-R1): Added support for a custom target architecture 