### PR TITLE
Add common data structures

### DIFF
--- a/kernel/src/interrupts/interrupt_types.hpp
+++ b/kernel/src/interrupts/interrupt_types.hpp
@@ -40,9 +40,7 @@ struct InterruptHandlerEntry {
     HandlerData handler_data{};
     u16 logical_irq{};
     u64 hardware_irq{};
-    template_lib::OptionalField<
-        kInterruptType == InterruptType::kHardwareInterrupt, InterruptDriver *>
-        driver{};
+    OPTIONAL_FIELD(kInterruptType == InterruptType::kHardwareInterrupt, InterruptDriver *) driver{};
 };
 
 template <InterruptType kInterruptType>

--- a/kernel/test/critbit_tree_test.cpp
+++ b/kernel/test/critbit_tree_test.cpp
@@ -1,0 +1,171 @@
+#include <test_module/test.hpp>
+
+#include <data_structures/critbit_tree.hpp>
+#include <optional.hpp>
+#include <trace_framework.hpp>
+
+using namespace data_structures;
+
+class CritBitTreeTest : public TestGroupBase
+{
+};
+
+TEST_F(CritBitTreeTest, InsertAndContains)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_FALSE(tree.Contains("key1"));
+    R_ASSERT_TRUE(tree.Insert("key1", 42));
+    R_ASSERT_TRUE(tree.Contains("key1"));
+
+    R_ASSERT_FALSE(tree.Contains("key2"));
+    R_ASSERT_TRUE(tree.Insert("key2", 67));
+    R_ASSERT_TRUE(tree.Contains("key2"));
+}
+
+TEST_F(CritBitTreeTest, InsertOverwrite)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_TRUE(tree.Insert("key", 42));
+    R_ASSERT_TRUE(tree.Contains("key"));
+
+    R_ASSERT_FALSE(tree.Insert<false>("key", 67));
+    R_ASSERT_TRUE(tree.Contains("key"));
+
+    R_ASSERT_TRUE(tree.Insert<true>("key", 67));
+    R_ASSERT_TRUE(tree.Contains("key"));
+}
+
+TEST_F(CritBitTreeTest, Get)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_TRUE(tree.Insert("key", 42));
+
+    auto retrieved = tree.Get("key");
+    R_ASSERT_TRUE(retrieved);
+    R_ASSERT_EQ(42, **retrieved);
+
+    retrieved = tree.Get("nonexistent");
+    R_ASSERT_FALSE(retrieved.has_value());
+}
+
+TEST_F(CritBitTreeTest, Remove)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_TRUE(tree.Insert("key", 42));
+    R_ASSERT_TRUE(tree.Contains("key"));
+
+    R_ASSERT_TRUE(tree.Remove("key"));
+    R_ASSERT_FALSE(tree.Contains("key"));
+
+    R_ASSERT_FALSE(tree.Remove("key"));
+}
+
+TEST_F(CritBitTreeTest, ComplexOperations)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_TRUE(tree.Insert("apple", 1));
+    R_ASSERT_TRUE(tree.Insert("banana", 2));
+    R_ASSERT_TRUE(tree.Insert("apricot", 3));
+    R_ASSERT_TRUE(tree.Insert("blueberry", 4));
+
+    R_ASSERT_TRUE(tree.Contains("apple"));
+    R_ASSERT_TRUE(tree.Contains("banana"));
+    R_ASSERT_TRUE(tree.Contains("apricot"));
+    R_ASSERT_TRUE(tree.Contains("blueberry"));
+
+    R_ASSERT_TRUE(tree.Remove("banana"));
+    R_ASSERT_FALSE(tree.Contains("banana"));
+
+    auto retrieved = tree.Get("apricot");
+    R_ASSERT_TRUE(retrieved);
+    R_ASSERT_EQ(3, **retrieved);
+}
+
+TEST_F(CritBitTreeTest, EmptyTreeOperations)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_FALSE(tree.Contains("key"));
+    R_ASSERT_FALSE(tree.Remove("key"));
+
+    auto retrieved = tree.Get("key");
+    R_ASSERT_FALSE(retrieved.has_value());
+}
+
+TEST_F(CritBitTreeTest, InsertSimilarKeys)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_TRUE(tree.Insert("test", 10));
+    R_ASSERT_TRUE(tree.Insert("testing", 20));
+    R_ASSERT_TRUE(tree.Insert("tester", 30));
+
+    R_ASSERT_TRUE(tree.Contains("test"));
+    R_ASSERT_TRUE(tree.Contains("testing"));
+    R_ASSERT_TRUE(tree.Contains("tester"));
+
+    auto retrieved = tree.Get("testing");
+    R_ASSERT_TRUE(retrieved);
+    R_ASSERT_EQ(20, **retrieved);
+}
+
+TEST_F(CritBitTreeTest, RemoveNonExistentKey)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_FALSE(tree.Remove("nonexistent"));
+
+    R_ASSERT_TRUE(tree.Insert("existent", 100));
+    R_ASSERT_TRUE(tree.Remove("existent"));
+    R_ASSERT_FALSE(tree.Remove("existent"));
+}
+
+TEST_F(CritBitTreeTest, ConstGet)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_TRUE(tree.Insert("constKey", 55));
+
+    const auto &const_tree = tree;
+    auto retrieved         = const_tree.Get("constKey");
+    R_ASSERT_TRUE(retrieved);
+    R_ASSERT_EQ(55, **retrieved);
+}
+
+TEST_F(CritBitTreeTest, IndexOperator)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_TRUE(tree.Insert("indexKey", 77));
+
+    auto retrieved = tree["indexKey"];
+    R_ASSERT_TRUE(retrieved);
+    R_ASSERT_EQ(77, **retrieved);
+
+    retrieved = tree["nonexistentKey"];
+    R_ASSERT_FALSE(retrieved.has_value());
+}
+
+TEST_F(CritBitTreeTest, ComplexFilePaths)
+{
+    CritBitTree<int> tree;
+
+    R_ASSERT_TRUE(tree.Insert("/home/user/docs", 1));
+    R_ASSERT_TRUE(tree.Insert("/home/user/images", 2));
+    R_ASSERT_TRUE(tree.Insert("/var/log/syslog", 3));
+    R_ASSERT_TRUE(tree.Insert("/etc/config/settings", 4));
+
+    R_ASSERT_TRUE(tree.Contains("/home/user/docs"));
+    R_ASSERT_TRUE(tree.Contains("/home/user/images"));
+    R_ASSERT_TRUE(tree.Contains("/var/log/syslog"));
+    R_ASSERT_TRUE(tree.Contains("/etc/config/settings"));
+
+    auto retrieved = tree.Get("/var/log/syslog");
+    R_ASSERT_TRUE(retrieved);
+    R_ASSERT_EQ(3, **retrieved);
+}

--- a/kernel/test/linked_list_test.cpp
+++ b/kernel/test/linked_list_test.cpp
@@ -1,0 +1,333 @@
+#include <data_structures/linked_list.hpp>
+#include <mem/cyclic_allocator.hpp>
+#include <test_module/test.hpp>
+
+// ------------------------------
+// SingleLinkedList
+// ------------------------------
+
+using IntSingleList = data_structures::SingleLinkedList<int>;
+
+class SingleLinkedListTest : public TestGroupBase
+{
+    public:
+    IntSingleList list;
+};
+
+TEST_F(SingleLinkedListTest, EmptyList)
+{
+    EXPECT_TRUE(list.Empty());
+    EXPECT_EQ(0_size, list.Size());
+    EXPECT_EQ(nullptr, list.GetHead());
+}
+
+TEST_F(SingleLinkedListTest, PushFront)
+{
+    list.PushFront(1);
+    EXPECT_EQ(1_size, list.Size());
+    EXPECT_EQ(1, list.Front());
+
+    list.PushFront(2);
+    EXPECT_EQ(2_size, list.Size());
+    EXPECT_EQ(2, list.Front());
+
+    list.PushFront(0);
+    EXPECT_EQ(3_size, list.Size());
+    EXPECT_EQ(0, list.Front());
+}
+
+TEST_F(SingleLinkedListTest, PopFront)
+{
+    list.PushFront(3);
+    list.PushFront(2);
+    list.PushFront(1);
+
+    list.PopFront();
+    EXPECT_EQ(2_size, list.Size());
+    EXPECT_EQ(2, list.Front());
+
+    list.PopFront();
+    EXPECT_EQ(1_size, list.Size());
+    EXPECT_EQ(3, list.Front());
+
+    list.PopFront();
+    EXPECT_TRUE(list.Empty());
+}
+
+TEST_F(SingleLinkedListTest, Clear)
+{
+    list.PushFront(1);
+    list.PushFront(2);
+    list.PushFront(3);
+
+    EXPECT_EQ(3_size, list.Size());
+    list.Clear();
+    EXPECT_TRUE(list.Empty());
+    EXPECT_EQ(0_size, list.Size());
+}
+
+TEST_F(SingleLinkedListTest, Iterator)
+{
+    list.PushFront(3);
+    list.PushFront(2);
+    list.PushFront(1);
+
+    int expected = 1;
+    for (auto value : list) {
+        EXPECT_EQ(expected, value);
+        ++expected;
+    }
+}
+
+TEST_F(SingleLinkedListTest, MoveConstructor)
+{
+    list.PushFront(2);
+    list.PushFront(1);
+
+    IntSingleList otherList(std::move(list));
+    EXPECT_TRUE(list.Empty());
+    EXPECT_EQ(2_size, otherList.Size());
+    EXPECT_EQ(1, otherList.Front());
+}
+
+TEST_F(SingleLinkedListTest, MoveAssignment)
+{
+    list.PushFront(2);
+    list.PushFront(1);
+
+    IntSingleList otherList;
+    otherList.PushFront(99);
+
+    otherList = std::move(list);
+    EXPECT_TRUE(list.Empty());
+    EXPECT_EQ(2_size, otherList.Size());
+    EXPECT_EQ(1, otherList.Front());
+}
+
+TEST_F(SingleLinkedListTest, CustomAllocator)
+{
+    data_structures::StaticSingleLinkedList<int, 8> list;
+
+    list.PushFront(3);
+    list.PushFront(2);
+    list.PushFront(1);
+
+    EXPECT_EQ(3_size, list.Size());
+    EXPECT_EQ(1, list.Front());
+
+    list.Clear();
+    EXPECT_EQ(0_size, list.Size());
+}
+
+TEST_F(SingleLinkedListTest, InsertAfter)
+{
+    auto *node1 = list.PushFront(1);
+    auto *node2 = list.InsertAfter(node1, 2);
+    list.InsertAfter(node2, 3);
+
+    EXPECT_EQ(3_size, list.Size());
+
+    int expected = 1;
+    for (auto value : list) {
+        EXPECT_EQ(expected, value);
+        ++expected;
+    }
+}
+
+TEST_F(SingleLinkedListTest, StructureSizes)
+{
+    EXPECT_EQ(16_size, sizeof(IntSingleList::Node));
+    EXPECT_EQ(16_size, sizeof(IntSingleList));
+}
+
+// ------------------------------
+// DoubleLinkedList
+// ------------------------------
+
+using IntDoubleList = data_structures::DoubleLinkedList<int>;
+
+class DoubleLinkedListTest : public TestGroupBase
+{
+    public:
+    IntDoubleList list;
+};
+
+TEST_F(DoubleLinkedListTest, EmptyList)
+{
+    EXPECT_TRUE(list.Empty());
+    EXPECT_EQ(0_size, list.Size());
+    EXPECT_EQ(nullptr, list.GetHead());
+    EXPECT_EQ(nullptr, list.GetTail());
+}
+
+TEST_F(DoubleLinkedListTest, PushFrontAndBack)
+{
+    list.PushFront(1);
+    EXPECT_EQ(1_size, list.Size());
+    EXPECT_EQ(1, list.Front());
+    EXPECT_EQ(1, list.Back());
+
+    list.PushBack(2);
+    EXPECT_EQ(2_size, list.Size());
+    EXPECT_EQ(1, list.Front());
+    EXPECT_EQ(2, list.Back());
+
+    list.PushFront(0);
+    EXPECT_EQ(3_size, list.Size());
+    EXPECT_EQ(0, list.Front());
+    EXPECT_EQ(2, list.Back());
+}
+
+TEST_F(DoubleLinkedListTest, PopFrontAndBack)
+{
+    list.PushBack(1);
+    list.PushBack(2);
+    list.PushBack(3);
+
+    list.PopFront();
+    EXPECT_EQ(2_size, list.Size());
+    EXPECT_EQ(2, list.Front());
+
+    list.PopBack();
+    EXPECT_EQ(1_size, list.Size());
+    EXPECT_EQ(2, list.Back());
+
+    list.PopBack();
+    EXPECT_TRUE(list.Empty());
+}
+
+TEST_F(DoubleLinkedListTest, RemoveNode)
+{
+    auto *node1 = list.PushBack(1);
+    auto *node2 = list.PushBack(2);
+    auto *node3 = list.PushBack(3);
+
+    list.Remove(node2);
+    EXPECT_EQ(2_size, list.Size());
+    EXPECT_EQ(1, list.Front());
+    EXPECT_EQ(3, list.Back());
+
+    list.Remove(node1);
+    EXPECT_EQ(1_size, list.Size());
+    EXPECT_EQ(3, list.Front());
+
+    list.Remove(node3);
+    EXPECT_TRUE(list.Empty());
+}
+
+TEST_F(DoubleLinkedListTest, MoveToFront)
+{
+    auto *node1 = list.PushBack(1);
+    auto *node2 = list.PushBack(2);
+    auto *node3 = list.PushBack(3);
+
+    list.MoveToFront(node3);
+    EXPECT_EQ(3, list.Front());
+    EXPECT_EQ(2, list.Back());
+
+    list.MoveToFront(node1);
+    EXPECT_EQ(1, list.Front());
+}
+
+TEST_F(DoubleLinkedListTest, MoveToBack)
+{
+    auto *node1 = list.PushBack(1);
+    auto *node2 = list.PushBack(2);
+    auto *node3 = list.PushBack(3);
+
+    list.MoveToBack(node1);
+    EXPECT_EQ(2, list.Front());
+    EXPECT_EQ(1, list.Back());
+
+    list.MoveToBack(node3);
+    EXPECT_EQ(3, list.Back());
+}
+
+TEST_F(DoubleLinkedListTest, Clear)
+{
+    list.PushBack(1);
+    list.PushBack(2);
+    list.PushBack(3);
+
+    EXPECT_EQ(3_size, list.Size());
+    list.Clear();
+    EXPECT_TRUE(list.Empty());
+    EXPECT_EQ(0_size, list.Size());
+}
+
+TEST_F(DoubleLinkedListTest, Iterator)
+{
+    list.PushBack(1);
+    list.PushBack(2);
+    list.PushBack(3);
+
+    int expected = 1;
+    for (auto value : list) {
+        EXPECT_EQ(expected, value);
+        ++expected;
+    }
+}
+
+TEST_F(DoubleLinkedListTest, MoveConstructor)
+{
+    list.PushBack(1);
+    list.PushBack(2);
+
+    IntDoubleList otherList(std::move(list));
+    EXPECT_TRUE(list.Empty());
+    EXPECT_EQ(2_size, otherList.Size());
+    EXPECT_EQ(1, otherList.Front());
+    EXPECT_EQ(2, otherList.Back());
+}
+
+TEST_F(DoubleLinkedListTest, MoveAssignment)
+{
+    list.PushBack(1);
+    list.PushBack(2);
+
+    IntDoubleList otherList;
+    otherList.PushBack(99);
+
+    otherList = std::move(list);
+    EXPECT_TRUE(list.Empty());
+    EXPECT_EQ(2_size, otherList.Size());
+    EXPECT_EQ(1, otherList.Front());
+    EXPECT_EQ(2, otherList.Back());
+}
+
+TEST_F(DoubleLinkedListTest, CustomAllocator)
+{
+    data_structures::StaticDoubleLinkedList<int, 8> list;
+
+    list.PushBack(1);
+    list.PushBack(2);
+    list.PushBack(3);
+
+    EXPECT_EQ(3_size, list.Size());
+    EXPECT_EQ(1, list.Front());
+    EXPECT_EQ(3, list.Back());
+
+    list.Clear();
+    EXPECT_EQ(0_size, list.Size());
+}
+
+TEST_F(DoubleLinkedListTest, InsertAfter)
+{
+    auto *node1 = list.PushBack(1);
+    auto *node2 = list.InsertAfter(node1, 2);
+    list.InsertAfter(node2, 3);
+
+    EXPECT_EQ(3_size, list.Size());
+
+    int expected = 1;
+    for (auto value : list) {
+        EXPECT_EQ(expected, value);
+        ++expected;
+    }
+}
+
+TEST_F(DoubleLinkedListTest, StructureSizes)
+{
+    EXPECT_EQ(24_size, sizeof(IntDoubleList::Node));  // 20 + 4 bytes padding
+    EXPECT_EQ(24_size, sizeof(IntDoubleList));
+}

--- a/kernel/test/lru_cache_tests.cpp
+++ b/kernel/test/lru_cache_tests.cpp
@@ -1,0 +1,78 @@
+#include <data_structures/lru_cache.hpp>
+#include <test_module/test.hpp>
+
+class LruCacheTest : public TestGroupBase
+{
+    public:
+    data_structures::LruCache<int, int, 3> cache;
+};
+
+TEST_F(LruCacheTest, InsertionAndLookup)
+{
+    cache.Put(1, 10);
+    cache.Put(2, 20);
+    cache.Put(3, 30);
+
+    EXPECT_EQ(3_size, cache.Size());
+    EXPECT_EQ(30, *cache.Get(3));
+    EXPECT_EQ(20, *cache.Get(2));
+    EXPECT_EQ(10, *cache.Get(1));
+    EXPECT_EQ(nullptr, cache.Get(42));
+}
+
+TEST_F(LruCacheTest, UpdateKeepsSizeAndMovesToFront)
+{
+    cache.Put(1, 10);
+    cache.Put(2, 20);
+    cache.Put(3, 30);
+
+    cache.Put(2, 200);
+    EXPECT_EQ(3_size, cache.Size());
+    EXPECT_EQ(200, *cache.Get(2));
+
+    cache.Put(4, 40);
+    EXPECT_EQ(nullptr, cache.Get(1));
+    EXPECT_NOT_NULL(cache.Get(4));
+    EXPECT_NOT_NULL(cache.Get(2));
+    EXPECT_NOT_NULL(cache.Get(3));
+}
+
+TEST_F(LruCacheTest, EvictionOfLruEntry)
+{
+    cache.Put(1, 10);
+    cache.Put(2, 20);
+    cache.Put(3, 30);
+    EXPECT_NOT_NULL(cache.Get(1));
+
+    cache.Put(4, 30);
+    EXPECT_EQ(nullptr, cache.Get(2));
+    EXPECT_NOT_NULL(cache.Get(1));
+    EXPECT_NOT_NULL(cache.Get(3));
+
+    cache.Get(1);
+    cache.Put(5, 40);
+    EXPECT_EQ(nullptr, cache.Get(4));
+    EXPECT_NOT_NULL(cache.Get(3));
+    EXPECT_NOT_NULL(cache.Get(1));
+    EXPECT_NOT_NULL(cache.Get(5));
+    EXPECT_EQ(3_size, cache.Size());
+}
+
+TEST_F(LruCacheTest, EraseAndClear)
+{
+    cache.Put(1, 10);
+    cache.Put(2, 20);
+    cache.Put(3, 30);
+
+    EXPECT_EQ(3_size, cache.Size());
+    EXPECT_TRUE(cache.Erase(2));
+    EXPECT_EQ(nullptr, cache.Get(2));
+    EXPECT_EQ(2_size, cache.Size());
+
+    EXPECT_FALSE(cache.Erase(42));
+
+    cache.Clear();
+    EXPECT_EQ(0_size, cache.Size());
+    EXPECT_TRUE(cache.Empty());
+    EXPECT_EQ(nullptr, cache.Get(1));
+}

--- a/kernel/test/tagged_pointer_test.cpp
+++ b/kernel/test/tagged_pointer_test.cpp
@@ -1,0 +1,73 @@
+#include <test_module/test.hpp>
+
+#include <data_structures/tagged_pointer.hpp>
+
+using namespace data_structures;
+
+class TaggedPointerTest : public TestGroupBase
+{
+};
+
+struct AlignedStruct1 {
+    int value;
+    AlignedStruct1(int v) : value(v) {}
+};
+
+struct AlignedStruct2 {
+    long long a, b, c;
+
+    AlignedStruct2(long long x, long long y, long long z) : a(x), b(y), c(z) {}
+};
+
+using TagPtr = TaggedPointer<AlignedStruct1, AlignedStruct2>;
+
+TEST_F(TaggedPointerTest, BasicCreateAndIs)
+{
+    // Test Create with tag dispatch - uses universal reference binding
+    auto ptr1 = TagPtr::Construct<AlignedStruct1>(42);
+    R_ASSERT_TRUE(ptr1.IsValid());
+    R_ASSERT_TRUE(ptr1.Is<AlignedStruct1>());
+    R_ASSERT_FALSE(ptr1.Is<AlignedStruct2>());
+
+    auto ptr2 = TagPtr::Construct<AlignedStruct2>(1LL, 2LL, 3LL);
+    R_ASSERT_TRUE(ptr2.IsValid());
+    R_ASSERT_FALSE(ptr2.Is<AlignedStruct1>());
+    R_ASSERT_TRUE(ptr2.Is<AlignedStruct2>());
+}
+
+TEST_F(TaggedPointerTest, AsMethod)
+{
+    auto ptr1 = TagPtr::Construct<AlignedStruct1>(100);
+
+    auto &s1 = ptr1.As<AlignedStruct1>();
+    R_ASSERT_EQ(100, s1.value);
+
+    auto ptr2 = TagPtr::Construct<AlignedStruct2>(10LL, 20LL, 30LL);
+
+    auto &s2 = ptr2.As<AlignedStruct2>();
+    R_ASSERT_EQ(10LL, s2.a);
+    R_ASSERT_EQ(20LL, s2.b);
+    R_ASSERT_EQ(30LL, s2.c);
+}
+
+TEST_F(TaggedPointerTest, MoveSemantics)
+{
+    auto ptr1 = TagPtr::Construct<AlignedStruct1>(123);
+    R_ASSERT_TRUE(ptr1.IsValid());
+
+    // Move construction
+    auto ptr2 = std::move(ptr1);
+    R_ASSERT_FALSE(ptr1.IsValid());  // moved-from object is invalid
+    R_ASSERT_TRUE(ptr2.IsValid());
+    R_ASSERT_EQ(123, ptr2.As<AlignedStruct1>().value);
+
+    // Move assignment
+    auto ptr3 = TagPtr::Construct<AlignedStruct2>(5LL, 10LL, 15LL);
+    R_ASSERT_TRUE(ptr3.IsValid());
+
+    ptr3 = std::move(ptr2);
+    R_ASSERT_FALSE(ptr2.IsValid());  // moved-from object is invalid
+    R_ASSERT_TRUE(ptr3.IsValid());
+    R_ASSERT_TRUE(ptr3.Is<AlignedStruct1>());
+    R_ASSERT_EQ(123, ptr3.As<AlignedStruct1>().value);
+}

--- a/libs/libcontainers/include/allocators/custom_allocator_wrapper.hpp
+++ b/libs/libcontainers/include/allocators/custom_allocator_wrapper.hpp
@@ -32,7 +32,7 @@ class CustomAllocatorWrapper : decltype(AllocateFunc), decltype(DeallocateFunc)
 
 template <typename T>
 using KMallocAllocator = CustomAllocatorWrapper<
-    []<typename... Args>(this auto &self, Args &&...args) FORCE_INLINE_L {
+    []<typename... Args>(this auto &, Args &&...args) FORCE_INLINE_L {
         auto mem = Mem::KMalloc<T>();
         if (!mem) {
             return static_cast<T *>(nullptr);
@@ -40,7 +40,7 @@ using KMallocAllocator = CustomAllocatorWrapper<
 
         return new (*mem) T(std::forward<Args>(args)...);
     },
-    []<typename U>(this auto &self, U *ptr) FORCE_INLINE_L {
+    []<typename U>(this auto &, U *ptr) FORCE_INLINE_L {
         if (ptr) {
             ptr->~U();
             Mem::KFree(ptr);

--- a/libs/libcontainers/include/allocators/custom_allocator_wrapper.hpp
+++ b/libs/libcontainers/include/allocators/custom_allocator_wrapper.hpp
@@ -1,0 +1,62 @@
+#ifndef LIBS_LIBCONTAINERS_INCLUDE_ALLOCATORS_CUSTOM_ALLOCATOR_WRAPPER_HPP_
+#define LIBS_LIBCONTAINERS_INCLUDE_ALLOCATORS_CUSTOM_ALLOCATOR_WRAPPER_HPP_
+
+#include <mem/cyclic_allocator.hpp>
+#include <mem/heap.hpp>
+#include <template_lib.hpp>
+#include <type_traits.hpp>
+
+namespace allocators
+{
+
+template <decltype(auto) AllocateFunc, decltype(auto) DeallocateFunc, typename AllocatorT = void>
+class CustomAllocatorWrapper : decltype(AllocateFunc), decltype(DeallocateFunc)
+{
+    static constexpr bool kCondition = !std::is_void_v<AllocatorT>;
+
+    public:
+    template <typename U, typename... Args>
+    FORCE_INLINE_F U *Allocate(Args &&...args)
+    {
+        return decltype(AllocateFunc)::operator()(std::forward<Args>(args)...);
+    }
+
+    template <typename U>
+    FORCE_INLINE_F void Deallocate(U *ptr)
+    {
+        decltype(DeallocateFunc)::operator()(ptr);
+    }
+
+    OPTIONAL_FIELD(kCondition, AllocatorT) Allocator {};
+};
+
+template <typename T>
+using KMallocAllocator = CustomAllocatorWrapper<
+    []<typename... Args>(this auto &self, Args &&...args) FORCE_INLINE_L {
+        auto mem = Mem::KMalloc<T>();
+        if (!mem) {
+            return static_cast<T *>(nullptr);
+        }
+
+        return new (*mem) T(std::forward<Args>(args)...);
+    },
+    []<typename U>(this auto &self, U *ptr) FORCE_INLINE_L {
+        if (ptr) {
+            ptr->~U();
+            Mem::KFree(ptr);
+        }
+    }>;
+
+template <typename T, size_t kPoolSize>
+using CyclicAllocatorWrapper = CustomAllocatorWrapper<
+    []<typename... Args>(this auto &self, Args &&...args) FORCE_INLINE_L {
+        return self.Allocator.Allocate(std::forward<Args>(args)...);
+    },
+    []<typename U>(this auto &self, U *ptr) FORCE_INLINE_L {
+        self.Allocator.Free(ptr);
+    },
+    CyclicAllocator<T, kPoolSize>>;
+
+}  // namespace allocators
+
+#endif  // LIBS_LIBCONTAINERS_INCLUDE_ALLOCATORS_CUSTOM_ALLOCATOR_WRAPPER_HPP_

--- a/libs/libcontainers/include/data_structures/critbit_tree.hpp
+++ b/libs/libcontainers/include/data_structures/critbit_tree.hpp
@@ -1,0 +1,373 @@
+#ifndef LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_CRITBIT_TREE_HPP_
+#define LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_CRITBIT_TREE_HPP_
+
+#include <string.h>
+#include <data_structures/bit_array.hpp>
+#include <data_structures/tagged_pointer.hpp>
+#include <mem/heap.hpp>
+#include <new.hpp>
+#include <optional.hpp>
+#include <string.hpp>
+
+namespace data_structures
+{
+
+// Crit-bit tree reference:
+// https://github.com/agl/critbit/blob/4bb69901a9813de05331bd3afc5085e00050f701/critbit.pdf
+
+/**
+ * @brief A binary crit-bit tree implementation for NUL-terminated strings.
+ *
+ * This implementation uses a `TaggedPointer` to distinguish between
+ * internal nodes and external nodes.
+ *
+ * @tparam T The type of value stored in the tree.
+ */
+template <typename T>
+class CritBitTree
+{
+    // Forward declarations
+    struct ExternalNode;
+    struct InternalNode;
+
+    // Tag 0: ExternalNode
+    // Tag 1: InternalNode
+    using NodePtr = TaggedPointer<ExternalNode, InternalNode>;
+
+    struct ExternalNode {
+        char *key;
+        T value;
+
+        template <typename... Args>
+        ExternalNode(const char *k, Args &&...args) : value(std::forward<Args>(args)...)
+        {
+            const size_t len = strlen(k);
+            key              = static_cast<char *>(Mem::KMalloc(len + 1).value_or(nullptr));
+            if (key) {
+                strncpy(key, k, len + 1);
+            }
+        }
+
+        ~ExternalNode()
+        {
+            if (key) {
+                Mem::KFree(key);
+            }
+        }
+    };
+
+    struct InternalNode {
+        NodePtr child[2];
+        u32 byte;
+        u8 mask;
+
+        InternalNode(u32 b, u8 o) : byte(b), mask(o) {}
+        ~InternalNode() = default;
+    };
+
+    public:
+    using value_type    = T;
+    using pointer       = value_type *;
+    using const_pointer = const value_type *;
+
+    // -----------------------------------------------------------------------------
+    // Construction / Destruction
+    // -----------------------------------------------------------------------------
+
+    CritBitTree() = default;
+
+    ~CritBitTree() { Clear(); }
+
+    CritBitTree(const CritBitTree &)            = delete;
+    CritBitTree &operator=(const CritBitTree &) = delete;
+
+    CritBitTree(CritBitTree &&other) noexcept : root_(std::move(other.root_)) {}
+
+    CritBitTree &operator=(CritBitTree &&other) noexcept
+    {
+        if (this != &other) {
+            root_ = std::move(other.root_);
+        }
+        return *this;
+    }
+
+    // -----------------------------------------------------------------------------
+    // Public API
+    // -----------------------------------------------------------------------------
+
+    void Clear() { root_ = {}; }
+
+    /**
+     * @brief Checks if a key exists in the tree.
+     */
+    NODISCARD FORCE_INLINE_F bool Contains(std::string_view key) const
+    {
+        const ExternalNode *match = GetBestMatch_(key);
+        if (!match) {
+            return false;
+        }
+
+        return std::string_view(match->key) == key;
+    }
+
+    /**
+     * @brief Retrieves a pointer to the value associated with the key.
+     * @return An optional containing the pointer, or empty if not found.
+     */
+    NODISCARD FORCE_INLINE_F std::optional<pointer> Get(std::string_view key)
+    {
+        ExternalNode *match = GetBestMatch_(key);
+        if (!match) {
+            return {};
+        }
+
+        if (std::string_view(match->key) != key) {
+            return {};
+        }
+
+        auto ret = std::optional<pointer>();
+        ret.emplace(&match->value);
+
+        return ret;
+    }
+
+    /**
+     * @brief Retrieves a const pointer to the value associated with the key.
+     */
+    NODISCARD FORCE_INLINE_F std::optional<const_pointer> Get(std::string_view key) const
+    {
+        const ExternalNode *match = GetBestMatch_(key);
+        if (!match) {
+            return {};
+        }
+
+        if (std::string_view(match->key) != key) {
+            return {};
+        }
+
+        auto ret = std::optional<const_pointer>();
+        ret.emplace(&match->value);
+
+        return ret;
+    }
+
+    NODISCARD FORCE_INLINE_F std::optional<pointer> operator[](std::string_view key)
+    {
+        return Get(key);
+    }
+    NODISCARD FORCE_INLINE_F std::optional<const_pointer> operator[](std::string_view key) const
+    {
+        return Get(key);
+    }
+
+    /**
+     * @brief Get Longest Prefix Match for the given key.
+     * @param key The key to search for.
+     * @return An optional containing a pointer to the value, or empty if no match found.
+     */
+    NODISCARD FORCE_INLINE_F std::optional<pointer> GetLongestPrefixMatch(std::string_view key)
+    {
+        ExternalNode *match = GetBestMatch_(key);
+        if (!match) {
+            return {};
+        }
+
+        auto ret = std::optional<pointer>();
+        ret.emplace(&match->value);
+        return ret;
+    }
+
+    /**
+     * @brief Inserts a key-value pair into the tree.
+     *
+     * @param key A NUL-terminated string allocated with Mem::KMalloc.
+     *            The tree takes ownership of this pointer.
+     *            If insertion fails (e.g., key exists and overwrite is false),
+     *            the key is freed by this function.
+     * @param args Arguments to construct the value T.
+     *
+     * @tparam overwrite If true, overwrites the value if the key already exists.
+     * @return true if inserted (or overwritten), false if key exists (and overwrite is false) or
+     * allocation failed.
+     */
+    template <bool overwrite = false, typename... Args>
+    bool Insert(const char *key, Args &&...args)
+    {
+        // 1. Handle insertion into an empty tree
+        if (!root_.IsValid()) {
+            root_ = NodePtr::template Construct<ExternalNode>(key, std::forward<Args>(args)...);
+            if (!root_.IsValid()) {
+                return false;
+            }
+            return true;
+        }
+
+        // 2. Walk tree for best member
+        ExternalNode *best_match = GetBestMatch_(key);
+
+        // 3. Check for successful membership (exact match)
+        // Find the first differing byte
+        const char *p = best_match->key;
+        size_t i      = 0;
+        while (p[i] != '\0' && key[i] == p[i]) {
+            i++;
+        }
+
+        // If we reached the end of both strings, it's a match
+        if (key[i] == '\0' && p[i] == '\0') {
+            if constexpr (overwrite) {
+                // Update value in place
+                best_match->value.~T();
+                new (&best_match->value) T(std::forward<Args>(args)...);
+                return true;
+            }
+            return false;
+        }
+
+        // 4. Find the critical bit
+        u32 newbyte = static_cast<u32>(i);
+        u32 newmask = 0;
+
+        // Get the differing bytes
+        u8 u_char = static_cast<u8>(key[newbyte]);
+        u8 p_char = static_cast<u8>(p[newbyte]);
+
+        newmask = u_char ^ p_char;
+
+        // Find the most significant differing bit.
+        newmask |= (newmask >> 1);
+        newmask |= (newmask >> 2);
+        newmask |= (newmask >> 4);
+        newmask = (newmask & ~(newmask >> 1)) ^ 255;
+
+        u8 mask = static_cast<u8>(newmask);
+
+        // 5. Allocate new internal node and external node
+        // Calculate direction for the new key at this critical bit
+        int dir = (1 + (mask | p_char)) >> 8;
+
+        NodePtr new_ext_node =
+            NodePtr::template Construct<ExternalNode>(key, std::forward<Args>(args)...);
+        if (!new_ext_node.IsValid()) {
+            return false;
+        }
+
+        NodePtr new_int_node = NodePtr::template Construct<InternalNode>(newbyte, mask);
+        if (!new_int_node.IsValid()) {
+            return false;
+        }
+
+        // Link the new external node
+        auto &internal_ref          = new_int_node.template As<InternalNode>();
+        internal_ref.child[1 - dir] = std::move(new_ext_node);
+
+        // 6. Insert new node into the tree
+        InsertInternalNode_(new_int_node, newbyte, mask, dir, key);
+
+        return true;
+    }
+
+    /**
+     * @brief Removes a key from the tree.
+     */
+    bool Remove(std::string_view key)
+    {
+        if (!root_.IsValid()) {
+            return false;
+        }
+
+        NodePtr *current = &root_;
+        NodePtr *parent  = nullptr;
+        InternalNode *q  = nullptr;
+        int dir          = 0;
+
+        const char *u     = key.data();
+        const size_t ulen = key.size();
+
+        // Walk to find best match, keeping track of parent
+        while (current->template Is<InternalNode>()) {
+            parent = current;
+            q      = &current->template As<InternalNode>();
+
+            const u8 c = (q->byte < ulen) ? static_cast<u8>(u[q->byte]) : 0;
+            dir        = (1 + (q->mask | c)) >> 8;
+            current    = &q->child[dir];
+        }
+
+        ExternalNode &p = current->template As<ExternalNode>();
+        if (std::string_view(p.key) != key) {
+            return false;
+        }
+
+        // Found it. Remove p.
+        // If it's the root (and it's external), the tree becomes empty.
+        if (!parent) {
+            root_ = {};
+            return true;
+        }
+
+        *parent = std::move(q->child[1 - dir]);
+        return true;
+    }
+
+    // -----------------------------------------------------------------------------
+    // Private Helpers
+    // -----------------------------------------------------------------------------
+
+    private:
+    ExternalNode *GetBestMatch_(std::string_view key) const
+    {
+        if (!root_.IsValid()) {
+            return nullptr;
+        }
+
+        const NodePtr *p  = &root_;
+        const char *u     = key.data();
+        const size_t ulen = key.size();
+
+        while (p->template Is<InternalNode>()) {
+            const InternalNode &q = p->template As<InternalNode>();
+            const u8 c            = (q.byte < ulen) ? static_cast<u8>(u[q.byte]) : 0;
+            int dir               = (1 + (q.mask | c)) >> 8;
+            p                     = &q.child[dir];
+        }
+
+        // p is now an ExternalNode
+        return &const_cast<NodePtr *>(p)->template As<ExternalNode>();
+    }
+
+    void InsertInternalNode_(
+        NodePtr &new_node_ptr, u32 newbyte, u8 newmask, int newdir, const char *key
+    )
+    {
+        NodePtr *wherep      = &root_;
+        const size_t key_len = strlen(key);
+
+        // Walk the tree again to find the insertion point.
+        // We insert above the first node that checks a bit position *after* our new critical bit.
+        while (wherep->template Is<InternalNode>()) {
+            InternalNode &q = wherep->template As<InternalNode>();
+            if (q.byte > newbyte || (q.byte == newbyte && q.mask > newmask)) {
+                break;
+            }
+
+            // Move down
+            const u8 c    = (q.byte < key_len) ? static_cast<u8>(key[q.byte]) : 0;
+            const int dir = (1 + (q.mask | c)) >> 8;
+            wherep        = &q.child[dir];
+        }
+
+        // The other child of the new node adopts the subtree we are replacing
+        auto &new_node         = new_node_ptr.template As<InternalNode>();
+        new_node.child[newdir] = std::move(*wherep);
+
+        // The parent points to the new node
+        *wherep = std::move(new_node_ptr);
+    }
+
+    NodePtr root_;
+};
+
+}  // namespace data_structures
+
+#endif  // LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_CRITBIT_TREE_HPP_

--- a/libs/libcontainers/include/data_structures/critbit_tree.hpp
+++ b/libs/libcontainers/include/data_structures/critbit_tree.hpp
@@ -102,7 +102,7 @@ class CritBitTree
      */
     NODISCARD FORCE_INLINE_F bool Contains(std::string_view key) const
     {
-        const ExternalNode *match = GetBestMatch_(key);
+        const ExternalNode *match = GetBestMatch(key);
         if (!match) {
             return false;
         }
@@ -116,7 +116,7 @@ class CritBitTree
      */
     NODISCARD FORCE_INLINE_F std::optional<pointer> Get(std::string_view key)
     {
-        ExternalNode *match = GetBestMatch_(key);
+        ExternalNode *match = GetBestMatch(key);
         if (!match) {
             return {};
         }
@@ -136,7 +136,7 @@ class CritBitTree
      */
     NODISCARD FORCE_INLINE_F std::optional<const_pointer> Get(std::string_view key) const
     {
-        const ExternalNode *match = GetBestMatch_(key);
+        const ExternalNode *match = GetBestMatch(key);
         if (!match) {
             return {};
         }
@@ -167,7 +167,7 @@ class CritBitTree
      */
     NODISCARD FORCE_INLINE_F std::optional<pointer> GetLongestPrefixMatch(std::string_view key)
     {
-        ExternalNode *match = GetBestMatch_(key);
+        ExternalNode *match = GetBestMatch(key);
         if (!match) {
             return {};
         }
@@ -180,10 +180,7 @@ class CritBitTree
     /**
      * @brief Inserts a key-value pair into the tree.
      *
-     * @param key A NUL-terminated string allocated with Mem::KMalloc.
-     *            The tree takes ownership of this pointer.
-     *            If insertion fails (e.g., key exists and overwrite is false),
-     *            the key is freed by this function.
+     * @param key A NUL-terminated string.
      * @param args Arguments to construct the value T.
      *
      * @tparam overwrite If true, overwrites the value if the key already exists.
@@ -203,7 +200,7 @@ class CritBitTree
         }
 
         // 2. Walk tree for best member
-        ExternalNode *best_match = GetBestMatch_(key);
+        ExternalNode *best_match = GetBestMatch(key);
 
         // 3. Check for successful membership (exact match)
         // Find the first differing byte
@@ -262,7 +259,7 @@ class CritBitTree
         internal_ref.child[1 - dir] = std::move(new_ext_node);
 
         // 6. Insert new node into the tree
-        InsertInternalNode_(new_int_node, newbyte, mask, dir, key);
+        InsertInternalNode(new_int_node, newbyte, mask, dir, key);
 
         return true;
     }
@@ -306,7 +303,7 @@ class CritBitTree
             return true;
         }
 
-        *parent = std::move(q->child[1 - dir]);
+        *parent = NodePtr(q->child[1 - dir].Release());
         return true;
     }
 
@@ -315,7 +312,7 @@ class CritBitTree
     // -----------------------------------------------------------------------------
 
     private:
-    ExternalNode *GetBestMatch_(std::string_view key) const
+    ExternalNode *GetBestMatch(std::string_view key) const
     {
         if (!root_.IsValid()) {
             return nullptr;
@@ -336,7 +333,7 @@ class CritBitTree
         return &const_cast<NodePtr *>(p)->template As<ExternalNode>();
     }
 
-    void InsertInternalNode_(
+    void InsertInternalNode(
         NodePtr &new_node_ptr, u32 newbyte, u8 newmask, int newdir, const char *key
     )
     {

--- a/libs/libcontainers/include/data_structures/linked_list.hpp
+++ b/libs/libcontainers/include/data_structures/linked_list.hpp
@@ -211,7 +211,7 @@ class LinkedList
     template <typename... Args>
     Node *EmplaceFront(Args &&...args)
     {
-        Node *node = AllocateNode_(std::forward<Args>(args)...);
+        Node *node = AllocateNode(std::forward<Args>(args)...);
         if (!node) {
             return nullptr;
         }
@@ -243,7 +243,7 @@ class LinkedList
     Node *PushBack(Args &&...args)
         requires(kIsDoubleLinked)
     {
-        Node *node = AllocateNode_(std::forward<Args>(args)...);
+        Node *node = AllocateNode(std::forward<Args>(args)...);
         if (!node) {
             return nullptr;
         }
@@ -275,7 +275,7 @@ class LinkedList
             return nullptr;
         }
 
-        Node *node = AllocateNode_(std::forward<Args>(args)...);
+        Node *node = AllocateNode(std::forward<Args>(args)...);
         if (!node) {
             return nullptr;
         }
@@ -313,7 +313,7 @@ class LinkedList
             }
         }
 
-        DeallocateNode_(node);
+        DeallocateNode(node);
         --size_;
     }
 
@@ -333,7 +333,7 @@ class LinkedList
             head_ = nullptr;
         }
 
-        DeallocateNode_(node);
+        DeallocateNode(node);
         --size_;
     }
 
@@ -359,7 +359,7 @@ class LinkedList
         node->prev = nullptr;
         node->next = nullptr;
 
-        DeallocateNode_(node);
+        DeallocateNode(node);
         --size_;
     }
 
@@ -434,7 +434,7 @@ class LinkedList
         Node *node = head_;
         while (node != nullptr) {
             Node *next = node->next;
-            DeallocateNode_(node);
+            DeallocateNode(node);
             node = next;
         }
 
@@ -459,12 +459,12 @@ class LinkedList
 
     private:
     template <typename... Args>
-    Node *AllocateNode_(Args &&...args)
+    Node *AllocateNode(Args &&...args)
     {
         return allocator_.template Allocate<Node>(std::forward<Args>(args)...);
     }
 
-    void DeallocateNode_(Node *node)
+    void DeallocateNode(Node *node)
     {
         if (node) {
             node->~Node();

--- a/libs/libcontainers/include/data_structures/linked_list.hpp
+++ b/libs/libcontainers/include/data_structures/linked_list.hpp
@@ -1,0 +1,505 @@
+#ifndef LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_LINKED_LIST_HPP_
+#define LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_LINKED_LIST_HPP_
+
+#include <stddef.h>
+#include <allocators/custom_allocator_wrapper.hpp>
+#include <new.hpp>
+#include <template/utils.hpp>
+#include <type_traits.hpp>
+#include <utility.hpp>
+
+namespace data_structures
+{
+
+namespace internal
+{
+template <typename T, bool kIsDoubleLinked = true>
+struct LinkedListNode {
+    T data;
+    OPTIONAL_FIELD(kIsDoubleLinked, LinkedListNode *) prev;
+    LinkedListNode *next;
+
+    template <typename... Args>
+    explicit LinkedListNode(Args &&...args)
+        : data(std::forward<Args>(args)...), prev{}, next(nullptr)
+    {
+    }
+};
+}  // namespace internal
+
+/**
+ * @brief A linked list that can be either singly or doubly-linked
+ *
+ * @tparam T The type of elements stored in the list.
+ * @tparam AllocatorT The allocator type
+ * @tparam kIsDoubleLinked If true, creates a doubly-linked list; if false, singly-linked
+ */
+template <typename T, typename AllocatorT, bool kIsDoubleLinked = true>
+class LinkedList
+{
+    public:
+    using Node = internal::LinkedListNode<T, kIsDoubleLinked>;
+
+    class Iterator
+    {
+        public:
+        using value_type = T;
+        using reference  = T &;
+        using pointer    = T *;
+
+        explicit Iterator(Node *node) : node_(node) {}
+
+        reference operator*() const { return node_->data; }
+        pointer operator->() const { return &node_->data; }
+
+        Iterator &operator++()
+        {
+            node_ = node_->next;
+            return *this;
+        }
+
+        Iterator operator++(int)
+        {
+            Iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        Iterator &operator--()
+            requires(kIsDoubleLinked)
+        {
+            node_ = node_->prev;
+            return *this;
+        }
+
+        Iterator operator--(int)
+            requires(kIsDoubleLinked)
+        {
+            Iterator tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        bool operator==(const Iterator &other) const { return node_ == other.node_; }
+        bool operator!=(const Iterator &other) const { return node_ != other.node_; }
+
+        Node *GetNode() const { return node_; }
+
+        private:
+        Node *node_;
+    };
+
+    class ConstIterator
+    {
+        public:
+        using value_type = const T;
+        using reference  = const T &;
+        using pointer    = const T *;
+
+        explicit ConstIterator(const Node *node) : node_(node) {}
+
+        reference operator*() const { return node_->data; }
+        pointer operator->() const { return &node_->data; }
+
+        ConstIterator &operator++()
+        {
+            node_ = node_->next;
+            return *this;
+        }
+
+        ConstIterator operator++(int)
+        {
+            ConstIterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        ConstIterator &operator--()
+            requires(kIsDoubleLinked)
+        {
+            node_ = node_->prev;
+            return *this;
+        }
+
+        ConstIterator operator--(int)
+            requires(kIsDoubleLinked)
+        {
+            ConstIterator tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        bool operator==(const ConstIterator &other) const { return node_ == other.node_; }
+        bool operator!=(const ConstIterator &other) const { return node_ != other.node_; }
+
+        const Node *GetNode() const { return node_; }
+
+        private:
+        const Node *node_;
+    };
+
+    // ------------------------------
+    // Class creation
+    // ------------------------------
+
+    public:
+    LinkedList() : head_(nullptr), tail_{}, size_(0) {}
+    ~LinkedList() { Clear(); }
+
+    LinkedList(const LinkedList &)            = delete;
+    LinkedList &operator=(const LinkedList &) = delete;
+
+    LinkedList(LinkedList &&other) noexcept
+        : head_(other.head_), tail_(other.tail_), size_(other.size_), allocator_(other.allocator_)
+    {
+        other.head_ = nullptr;
+        if constexpr (kIsDoubleLinked) {
+            other.tail_ = nullptr;
+        }
+        other.size_ = 0;
+    }
+
+    LinkedList &operator=(LinkedList &&other) noexcept
+    {
+        if (this != &other) {
+            Clear();
+            head_       = other.head_;
+            tail_       = other.tail_;
+            size_       = other.size_;
+            allocator_  = other.allocator_;
+            other.head_ = nullptr;
+            if constexpr (kIsDoubleLinked) {
+                other.tail_ = nullptr;
+            }
+            other.size_ = 0;
+        }
+        return *this;
+    }
+
+    // Capacity
+    size_t Size() const { return size_; }
+    bool Empty() const { return size_ == 0; }
+
+    // Element access
+    T &Front() { return head_->data; }
+    const T &Front() const { return head_->data; }
+
+    T &Back()
+        requires(kIsDoubleLinked)
+    {
+        return tail_->data;
+    }
+
+    const T &Back() const
+        requires(kIsDoubleLinked)
+    {
+        return tail_->data;
+    }
+
+    // Iterators
+    Iterator begin() { return Iterator(head_); }
+    Iterator end() { return Iterator(nullptr); }
+    ConstIterator begin() const { return ConstIterator(head_); }
+    ConstIterator end() const { return ConstIterator(nullptr); }
+
+    ConstIterator cbegin() const { return ConstIterator(head_); }
+    ConstIterator cend() const { return ConstIterator(nullptr); }
+
+    Node *PushFront(const T &value) { return EmplaceFront(value); }
+    Node *PushFront(T &&value) { return EmplaceFront(std::move(value)); }
+
+    template <typename... Args>
+    Node *EmplaceFront(Args &&...args)
+    {
+        Node *node = AllocateNode_(std::forward<Args>(args)...);
+        if (!node) {
+            return nullptr;
+        }
+
+        if constexpr (kIsDoubleLinked) {
+            node->prev = nullptr;
+        }
+        node->next = head_;
+
+        if constexpr (kIsDoubleLinked) {
+            if (head_ != nullptr) {
+                head_->prev = node;
+            }
+        }
+
+        head_ = node;
+
+        if constexpr (kIsDoubleLinked) {
+            if (tail_ == nullptr) {
+                tail_ = node;
+            }
+        }
+
+        ++size_;
+        return node;
+    }
+
+    template <typename... Args>
+    Node *PushBack(Args &&...args)
+        requires(kIsDoubleLinked)
+    {
+        Node *node = AllocateNode_(std::forward<Args>(args)...);
+        if (!node) {
+            return nullptr;
+        }
+
+        node->prev = tail_;
+        node->next = nullptr;
+
+        if (tail_ != nullptr) {
+            tail_->next = node;
+        }
+
+        tail_ = node;
+
+        if (head_ == nullptr) {
+            head_ = node;
+        }
+
+        ++size_;
+        return node;
+    }
+
+    Node *InsertAfter(Node *after, const T &value) { return EmplaceAfter(after, value); }
+    Node *InsertAfter(Node *after, T &&value) { return EmplaceAfter(after, std::move(value)); }
+
+    template <typename... Args>
+    Node *EmplaceAfter(Node *after, Args &&...args)
+    {
+        if (!after) {
+            return nullptr;
+        }
+
+        Node *node = AllocateNode_(std::forward<Args>(args)...);
+        if (!node) {
+            return nullptr;
+        }
+
+        node->next = after->next;
+        if constexpr (kIsDoubleLinked) {
+            node->prev = after;
+
+            if (after->next != nullptr) {
+                after->next->prev = node;
+            } else {
+                tail_ = node;
+            }
+        }
+        after->next = node;
+
+        ++size_;
+        return node;
+    }
+
+    void PopFront()
+    {
+        if (head_ == nullptr) {
+            return;
+        }
+
+        Node *node = head_;
+        head_      = head_->next;
+
+        if constexpr (kIsDoubleLinked) {
+            if (head_ != nullptr) {
+                head_->prev = nullptr;
+            } else {
+                tail_ = nullptr;
+            }
+        }
+
+        DeallocateNode_(node);
+        --size_;
+    }
+
+    void PopBack()
+        requires(kIsDoubleLinked)
+    {
+        if (tail_ == nullptr) {
+            return;
+        }
+
+        Node *node = tail_;
+        tail_      = tail_->prev;
+
+        if (tail_ != nullptr) {
+            tail_->next = nullptr;
+        } else {
+            head_ = nullptr;
+        }
+
+        DeallocateNode_(node);
+        --size_;
+    }
+
+    void Remove(Node *node)
+        requires(kIsDoubleLinked)
+    {
+        if (!node) {
+            return;
+        }
+
+        if (node->prev != nullptr) {
+            node->prev->next = node->next;
+        } else {
+            head_ = node->next;
+        }
+
+        if (node->next != nullptr) {
+            node->next->prev = node->prev;
+        } else {
+            tail_ = node->prev;
+        }
+
+        node->prev = nullptr;
+        node->next = nullptr;
+
+        DeallocateNode_(node);
+        --size_;
+    }
+
+    void MoveToFront(Node *node)
+        requires(kIsDoubleLinked)
+    {
+        if (!node || node == head_) {
+            return;
+        }
+
+        // Unlink from current position
+        if (node->prev != nullptr) {
+            node->prev->next = node->next;
+        }
+
+        if (node->next != nullptr) {
+            node->next->prev = node->prev;
+        } else {
+            tail_ = node->prev;
+        }
+
+        // Insert at front
+        node->prev = nullptr;
+        node->next = head_;
+
+        if (head_ != nullptr) {
+            head_->prev = node;
+        }
+
+        head_ = node;
+
+        if (tail_ == nullptr) {
+            tail_ = node;
+        }
+    }
+
+    void MoveToBack(Node *node)
+        requires(kIsDoubleLinked)
+    {
+        if (!node || node == tail_) {
+            return;
+        }
+
+        // Unlink from current position
+        if (node->prev != nullptr) {
+            node->prev->next = node->next;
+        } else {
+            head_ = node->next;
+        }
+
+        if (node->next != nullptr) {
+            node->next->prev = node->prev;
+        }
+
+        // Insert at back
+        node->prev = tail_;
+        node->next = nullptr;
+
+        if (tail_ != nullptr) {
+            tail_->next = node;
+        }
+
+        tail_ = node;
+
+        if (head_ == nullptr) {
+            head_ = node;
+        }
+    }
+
+    void Clear()
+    {
+        Node *node = head_;
+        while (node != nullptr) {
+            Node *next = node->next;
+            DeallocateNode_(node);
+            node = next;
+        }
+
+        head_ = nullptr;
+        if constexpr (kIsDoubleLinked) {
+            tail_ = nullptr;
+        }
+        size_ = 0;
+    }
+
+    Node *GetHead() const { return head_; }
+
+    Node *GetTail() const
+        requires(kIsDoubleLinked)
+    {
+        return tail_;
+    }
+
+    // ------------------------------
+    // Helpers
+    // ------------------------------
+
+    private:
+    template <typename... Args>
+    Node *AllocateNode_(Args &&...args)
+    {
+        return allocator_.template Allocate<Node>(std::forward<Args>(args)...);
+    }
+
+    void DeallocateNode_(Node *node)
+    {
+        if (node) {
+            node->~Node();
+            allocator_.template Deallocate<Node>(node);
+        }
+    }
+
+    // ------------------------------
+    // Field members
+    // ------------------------------
+
+    private:
+    Node *head_;
+    OPTIONAL_FIELD(kIsDoubleLinked, Node *) tail_;
+    size_t size_;
+    NO_UNIQUE_ADDRESS AllocatorT allocator_{};
+};
+
+template <
+    typename T, typename AllocatorT = allocators::KMallocAllocator<internal::LinkedListNode<T>>>
+using DoubleLinkedList = LinkedList<T, AllocatorT>;
+
+template <typename T, size_t kSize>
+using StaticDoubleLinkedList =
+    DoubleLinkedList<T, allocators::CyclicAllocatorWrapper<internal::LinkedListNode<T>, kSize>>;
+
+template <
+    typename T,
+    typename AllocatorT = allocators::KMallocAllocator<internal::LinkedListNode<T, false>>>
+using SingleLinkedList = LinkedList<T, AllocatorT, false>;
+
+template <typename T, size_t kSize>
+using StaticSingleLinkedList = SingleLinkedList<
+    T, allocators::CyclicAllocatorWrapper<internal::LinkedListNode<T, false>, kSize>>;
+
+}  // namespace data_structures
+
+#endif  // LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_LINKED_LIST_HPP_

--- a/libs/libcontainers/include/data_structures/lru_cache.hpp
+++ b/libs/libcontainers/include/data_structures/lru_cache.hpp
@@ -1,0 +1,112 @@
+#ifndef LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_LRU_CACHE_HPP_
+#define LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_LRU_CACHE_HPP_
+
+#include <stddef.h>
+#include <type_traits.hpp>
+
+#include <data_structures/hash_maps.hpp>
+#include <data_structures/linked_list.hpp>
+
+namespace data_structures
+{
+
+template <
+    typename KeyT, typename ValueT, size_t kCapacity,
+    class HashT = FastMinimalStaticHashmap<
+        KeyT, internal::LinkedListNode<std::tuple<const KeyT, ValueT>> *, kCapacity>>
+class LruCache
+{
+    static_assert(kCapacity > 0, "LRU cache capacity must be greater than zero");
+
+    public:
+    LruCache() = default;
+    ~LruCache() { Clear(); }
+
+    size_t Size() const { return list_.Size(); }
+    static constexpr size_t Capacity() { return kCapacity; }
+    bool Empty() const { return list_.Empty(); }
+
+    bool Contains(const KeyT &key) const { return hash_map_.HasKey(key); }
+
+    ValueT *Get(const KeyT &key)
+    {
+        auto node_ptr = hash_map_.Find(key);
+        if (!node_ptr) {
+            return nullptr;
+        }
+
+        ListNode *node = *node_ptr;
+        list_.MoveToFront(node);
+        return &std::get<1>(node->data);
+    }
+
+    const ValueT *Get(const KeyT &key) const
+    {
+        auto node_ptr = hash_map_.Find(key);
+        if (!node_ptr) {
+            return nullptr;
+        }
+
+        ListNode *node = *node_ptr;
+        const_cast<decltype(list_) &>(list_).MoveToFront(node);
+        return &std::get<1>(node->data);
+    }
+
+    void Put(const KeyT &key, ValueT value)
+    {
+        if (auto node_ptr = hash_map_.Find(key)) {
+            ListNode *node          = *node_ptr;
+            std::get<1>(node->data) = std::move(value);
+            list_.MoveToFront(node);
+            return;
+        }
+
+        if (list_.Size() == kCapacity) {
+            Evict_();
+        }
+
+        if (ListNode *new_node = list_.EmplaceFront(key, std::move(value))) {
+            hash_map_.Insert(std::get<0>(new_node->data), new_node);
+        }
+    }
+
+    bool Erase(const KeyT &key)
+    {
+        auto node_ptr = hash_map_.Find(key);
+        if (!node_ptr) {
+            return false;
+        }
+
+        ListNode *node = *node_ptr;
+        hash_map_.Remove(key);
+        list_.Remove(node);
+        return true;
+    }
+
+    void Clear()
+    {
+        list_.Clear();
+        hash_map_ = HashT();
+    }
+
+    private:
+    void Evict_()
+    {
+        ListNode *tail = list_.GetTail();
+        if (!tail) {
+            return;
+        }
+
+        hash_map_.Remove(std::get<0>(tail->data));
+        list_.PopBack();
+    }
+
+    DoubleLinkedList<std::tuple<const KeyT, ValueT>> list_{};
+    HashT hash_map_{};
+
+    using ListNode = decltype(list_)::Node;
+};
+
+}  // namespace data_structures
+
+#endif  // LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_LRU_CACHE_HPP_

--- a/libs/libcontainers/include/data_structures/lru_cache.hpp
+++ b/libs/libcontainers/include/data_structures/lru_cache.hpp
@@ -6,6 +6,10 @@
 
 #include <data_structures/hash_maps.hpp>
 #include <data_structures/linked_list.hpp>
+#include <todo.hpp>
+
+TODO_WHEN_MULTITHREADING
+// TODO: Make thread-safe
 
 namespace data_structures
 {
@@ -48,7 +52,6 @@ class LruCache
         }
 
         ListNode *node = *node_ptr;
-        const_cast<decltype(list_) &>(list_).MoveToFront(node);
         return &std::get<1>(node->data);
     }
 
@@ -62,7 +65,7 @@ class LruCache
         }
 
         if (list_.Size() == kCapacity) {
-            Evict_();
+            Evict();
         }
 
         if (ListNode *new_node = list_.EmplaceFront(key, std::move(value))) {
@@ -90,7 +93,7 @@ class LruCache
     }
 
     private:
-    void Evict_()
+    void Evict()
     {
         ListNode *tail = list_.GetTail();
         if (!tail) {

--- a/libs/libcontainers/include/data_structures/tagged_pointer.hpp
+++ b/libs/libcontainers/include/data_structures/tagged_pointer.hpp
@@ -36,15 +36,7 @@ class TaggedPointer
 
     explicit TaggedPointer(BaseT tagged_ptr) : tagged_ptr_(tagged_ptr) {}
 
-    ~TaggedPointer()
-    {
-        if (IsValid()) {
-            size_t tag           = GetTag();
-            size_t current_index = 0;
-
-            (void)((current_index++ == tag ? (Destroy<TaggedTypes>(), true) : false) || ...);
-        }
-    }
+    ~TaggedPointer() { Destroy(); }
 
     TaggedPointer(const TaggedPointer &)            = delete;
     TaggedPointer &operator=(const TaggedPointer &) = delete;
@@ -57,6 +49,7 @@ class TaggedPointer
     TaggedPointer &operator=(TaggedPointer &&other) noexcept
     {
         if (this != &other) {
+            Destroy();
             tagged_ptr_       = other.tagged_ptr_;
             other.tagged_ptr_ = 0;
         }
@@ -75,7 +68,8 @@ class TaggedPointer
         );
 
         auto mem = Mem::KMallocAligned(
-            {.size = sizeof(T), .alignment = alignof(T) > kTagBits ? alignof(T) : 1ULL << kTagBits}
+            {.size      = sizeof(T),
+             .alignment = alignof(T) > (1ULL << kTagBits) ? alignof(T) : (1ULL << kTagBits)}
         );
         if (!mem) {
             return {};
@@ -145,6 +139,16 @@ class TaggedPointer
     }
 
     private:
+    FORCE_INLINE_F void Destroy()
+    {
+        if (IsValid()) {
+            size_t tag           = GetTag();
+            size_t current_index = 0;
+
+            (void)((current_index++ == tag ? (DestroyType<TaggedTypes>(), true) : false) || ...);
+        }
+    }
+
     template <typename T>
     static constexpr size_t GetTypeIndex()
     {
@@ -166,7 +170,7 @@ class TaggedPointer
     NODISCARD FORCE_INLINE_F size_t GetTag() const { return tagged_ptr_ & kTagMask; }
 
     template <typename T>
-    void Destroy()
+    void DestroyType()
     {
         T *ptr = static_cast<T *>(UntagPtr());
         ptr->~T();

--- a/libs/libcontainers/include/data_structures/tagged_pointer.hpp
+++ b/libs/libcontainers/include/data_structures/tagged_pointer.hpp
@@ -1,0 +1,210 @@
+#ifndef LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_TAGGED_POINTER_HPP_
+#define LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_TAGGED_POINTER_HPP_
+
+#include <algorithm.hpp>
+#include <defines.hpp>
+#include <mem/heap.hpp>
+#include <new.hpp>
+#include <type_traits.hpp>
+#include <utility.hpp>
+
+namespace data_structures
+{
+/**
+ * @brief A tagged pointer that stores type information in unused pointer bits.
+ *
+ * The number of available tag bits is determined by the number of types provided.
+ *
+ * @tparam TaggedTypes Variadic list of types that can be stored with this tagged pointer
+ */
+template <typename... TaggedTypes>
+class TaggedPointer
+{
+    public:
+    using BaseT = uintptr_t;
+
+    static constexpr size_t kNumTypes = sizeof...(TaggedTypes);
+    static constexpr size_t kTagBits  = []() constexpr {
+        size_t bits = 0;
+        while ((1ULL << bits) < kNumTypes) {
+            bits++;
+        }
+        return bits;
+    }();
+
+    TaggedPointer() = default;
+
+    explicit TaggedPointer(BaseT tagged_ptr) : tagged_ptr_(tagged_ptr) {}
+
+    ~TaggedPointer()
+    {
+        if (IsValid()) {
+            size_t tag           = GetTag();
+            size_t current_index = 0;
+
+            (void)((current_index++ == tag ? (Destroy<TaggedTypes>(), true) : false) || ...);
+        }
+    }
+
+    TaggedPointer(const TaggedPointer &)            = delete;
+    TaggedPointer &operator=(const TaggedPointer &) = delete;
+
+    TaggedPointer(TaggedPointer &&other) noexcept : tagged_ptr_(other.tagged_ptr_)
+    {
+        other.tagged_ptr_ = 0;
+    }
+
+    TaggedPointer &operator=(TaggedPointer &&other) noexcept
+    {
+        if (this != &other) {
+            tagged_ptr_       = other.tagged_ptr_;
+            other.tagged_ptr_ = 0;
+        }
+        return *this;
+    }
+
+    NODISCARD FORCE_INLINE_F bool IsValid() const { return tagged_ptr_ != 0; }
+
+    NODISCARD FORCE_INLINE_F explicit operator bool() const { return IsValid(); }
+
+    template <typename T, typename... Args>
+    NODISCARD FAST_CALL TaggedPointer Construct(Args &&...args)
+    {
+        static_assert(
+            (std::is_same_v<T, TaggedTypes> || ...), "Type T must be one of the TaggedTypes"
+        );
+
+        auto mem = Mem::KMallocAligned(
+            {.size = sizeof(T), .alignment = alignof(T) > kTagBits ? alignof(T) : 1ULL << kTagBits}
+        );
+        if (!mem) {
+            return {};
+        }
+
+        T *ptr = new (*mem) T(std::forward<Args>(args)...);
+
+        return TaggedPointer(TagPtr(ptr, GetTypeIndex<T>()));
+    }
+
+    template <typename T>
+    NODISCARD FORCE_INLINE_F bool Is() const
+    {
+        static_assert(
+            (std::is_same_v<T, TaggedTypes> || ...), "Type T must be one of the TaggedTypes"
+        );
+        return IsValid() && GetTag() == GetTypeIndex<T>();
+    }
+
+    template <typename T>
+    NODISCARD FORCE_INLINE_F T &As()
+    {
+        ASSERT_TRUE(Is<T>());
+        return *static_cast<T *>(UntagPtr());
+    }
+
+    template <typename T>
+    NODISCARD FORCE_INLINE_F const T &As() const
+    {
+        ASSERT_TRUE(Is<T>());
+        return *static_cast<const T *>(UntagPtr());
+    }
+
+    // Visitor pattern to handle different types
+    template <typename Visitor>
+    FORCE_INLINE_F decltype(auto) Visit(Visitor &&visitor)
+    {
+        ASSERT_TRUE(IsValid());
+        size_t tag           = GetTag();
+        size_t current_index = 0;
+
+        // Dispatch to the correct type
+        return VisitImpl<Visitor, TaggedTypes...>(
+            std::forward<Visitor>(visitor), tag, current_index
+        );
+    }
+
+    template <typename Visitor>
+    FORCE_INLINE_F decltype(auto) Visit(Visitor &&visitor) const
+    {
+        ASSERT_TRUE(IsValid());
+        size_t tag           = GetTag();
+        size_t current_index = 0;
+
+        return VisitImpl<Visitor, TaggedTypes...>(
+            std::forward<Visitor>(visitor), tag, current_index
+        );
+    }
+
+    NODISCARD FORCE_INLINE_F uintptr_t GetRaw() const { return tagged_ptr_; }
+
+    NODISCARD FORCE_INLINE_F uintptr_t Release()
+    {
+        uintptr_t tmp = tagged_ptr_;
+        tagged_ptr_   = 0;
+        return tmp;
+    }
+
+    private:
+    template <typename T>
+    static constexpr size_t GetTypeIndex()
+    {
+        size_t index = 0;
+        ((std::is_same_v<T, TaggedTypes> ? true : (++index, false)) || ...);
+        return index;
+    }
+
+    NODISCARD FORCE_INLINE_F static BaseT TagPtr(void *ptr, size_t type_index)
+    {
+        return reinterpret_cast<BaseT>(ptr) | type_index;
+    }
+
+    NODISCARD FORCE_INLINE_F void *UntagPtr() const
+    {
+        return reinterpret_cast<void *>(tagged_ptr_ & kPtrMask);
+    }
+
+    NODISCARD FORCE_INLINE_F size_t GetTag() const { return tagged_ptr_ & kTagMask; }
+
+    template <typename T>
+    void Destroy()
+    {
+        T *ptr = static_cast<T *>(UntagPtr());
+        ptr->~T();
+        Mem::KFreeAligned(ptr);
+    }
+
+    template <typename Visitor, typename T, typename... Rest>
+    decltype(auto) VisitImpl(Visitor &&visitor, size_t tag, size_t &current_index)
+    {
+        if (current_index == tag) {
+            return visitor(As<T>());
+        }
+        current_index++;
+        if constexpr (sizeof...(Rest) > 0) {
+            return VisitImpl<Visitor, Rest...>(std::forward<Visitor>(visitor), tag, current_index);
+        }
+        R_FAIL_ALWAYS("Invalid tag in TaggedPointer::Visit");
+    }
+
+    template <typename Visitor, typename T, typename... Rest>
+    decltype(auto) VisitImpl(Visitor &&visitor, size_t tag, size_t &current_index) const
+    {
+        if (current_index == tag) {
+            return visitor(As<T>());
+        }
+        current_index++;
+        if constexpr (sizeof...(Rest) > 0) {
+            return VisitImpl<Visitor, Rest...>(std::forward<Visitor>(visitor), tag, current_index);
+        }
+        R_FAIL_ALWAYS("Invalid tag in TaggedPointer::Visit");
+    }
+
+    static constexpr BaseT kTagMask = (static_cast<BaseT>(1) << kTagBits) - 1;
+    static constexpr BaseT kPtrMask = ~kTagMask;
+
+    BaseT tagged_ptr_{};
+};
+
+}  // namespace data_structures
+
+#endif  // LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_TAGGED_POINTER_HPP_

--- a/libs/libtemplate/include/template/utils.hpp
+++ b/libs/libtemplate/include/template/utils.hpp
@@ -1,15 +1,17 @@
 #ifndef LIBS_LIBTEMPLATE_INCLUDE_TEMPLATE_UTILS_HPP_
 #define LIBS_LIBTEMPLATE_INCLUDE_TEMPLATE_UTILS_HPP_
 
-#include <variant.hpp>
+#include <defines.hpp>
+#include <type_traits.hpp>
 
 namespace template_lib
 {
 // ------------------------------
-// OptionalField
+// OPTIONAL_FIELD
 // ------------------------------
 
-template <bool cond, class T>
-using OptionalField = std::conditional_t<cond, T, std::monostate>;
+// Apparently using OptionalField = std::conditional_t<...> does not work
+#define OPTIONAL_FIELD(cond, type) NO_UNIQUE_ADDRESS std::conditional_t<cond, type, UNIQUE_EMPTY>
+
 }  // namespace template_lib
 #endif  // LIBS_LIBTEMPLATE_INCLUDE_TEMPLATE_UTILS_HPP_


### PR DESCRIPTION
Introduce several new data structures and allocator wrappers:
- CritBitTree: A binary crit-bit tree for NUL-terminated strings.
- LinkedList: Generic single and double linked lists with custom allocators.
- LruCache: A fixed-capacity LRU cache.
- TaggedPointer: Stores type info in unused pointer bits.
- CustomAllocatorWrapper: Enables using custom allocators with containers.
