### PR TITLE
Kryczkal/ucapi 01

### DIFF
--- a/kernel/arch/x86_64/boot/lib/abi/transition_data.hpp
+++ b/kernel/arch/x86_64/boot/lib/abi/transition_data.hpp
@@ -48,6 +48,9 @@ struct alignas(64) KernelArguments {
     u64 ramdisk_start;
     u64 ramdisk_end;
 
+    /// ACPI
+    u64 acpi_rsdp_phys_addr;
+
     /// Multiboot
     u64 multiboot_info_addr;
     u64 multiboot_header_start_addr;

--- a/kernel/arch/x86_64/boot/loader_64/src/main.cpp
+++ b/kernel/arch/x86_64/boot/loader_64/src/main.cpp
@@ -273,6 +273,24 @@ static void PrepareKernelArgs(
         gKernelInitialParams.ramdisk_start = 0;
         gKernelInitialParams.ramdisk_end   = 0;
     }
+
+    // ACPI
+    auto acpi_new_tag_res = multiboot_info.FindTag<TagNewAcpi>();
+    if (acpi_new_tag_res) {
+        const auto *tag                          = acpi_new_tag_res.value();
+        gKernelInitialParams.acpi_rsdp_phys_addr = reinterpret_cast<u64>(tag->rsdp);
+        TRACE_INFO("ACPI RSDP (v2) found at: 0x%llX", gKernelInitialParams.acpi_rsdp_phys_addr);
+    } else {
+        auto acpi_old_tag_res = multiboot_info.FindTag<TagOldAcpi>();
+        if (acpi_old_tag_res) {
+            const auto *tag                          = acpi_old_tag_res.value();
+            gKernelInitialParams.acpi_rsdp_phys_addr = reinterpret_cast<u64>(tag->rsdp);
+            TRACE_INFO("ACPI RSDP (v1) found at: 0x%llX", gKernelInitialParams.acpi_rsdp_phys_addr);
+        } else {
+            TRACE_WARNING("No ACPI RSDP tag found!");
+            gKernelInitialParams.acpi_rsdp_phys_addr = 0;
+        }
+    }
 }
 
 NO_RET static void TransitionToKernel(

--- a/kernel/arch/x86_64/src/drivers/hpet/hpet.cpp
+++ b/kernel/arch/x86_64/src/drivers/hpet/hpet.cpp
@@ -128,6 +128,10 @@ Hpet::Hpet(acpi_hpet *table)
     hpet_entry.stop_counter   = StopCounterCb;
     hpet_entry.resume_counter = ResumeCounterCb;
 
+    hpet_entry.clock_numerator = clock_period_;
+    hpet_entry.clock_denominator =
+        1'000'000;  // Convert femtoseconds (10^-15) to nanoseconds (10^-9)
+
     /* Own data */
     hpet_entry.own_data = this;
 

--- a/kernel/arch/x86_64/src/interrupts/idt.nasm
+++ b/kernel/arch/x86_64/src/interrupts/idt.nasm
@@ -59,7 +59,7 @@ isr_wrapper_%+%1:
     sub rsp, _shadow_space      ; Allocate shadow space.
     cld                         ; Clear direction flag.
     mov rdi, %1                 ; Arg1: interrupt number.
-    lea rsi, [rsp + _shadow_space + _reg_size + 8] ; Arg2: pointer to stack frame.
+    lea rsi, [rsp + _shadow_space + _reg_size] ; Arg2: pointer to stack frame.
     call HandleException
     add rsp, _shadow_space      ; Deallocate shadow space.
     pop_regs                    ; Restore registers.
@@ -77,7 +77,7 @@ isr_wrapper_%+%1:
     sub rsp, _shadow_space      ; Allocate shadow space.
     cld                         ; Clear direction flag.
     mov rdi, %1                 ; Arg1: interrupt number.
-    lea rsi, [rsp + _shadow_space + _reg_size + 8] ; Arg2: pointer to stack frame.
+    lea rsi, [rsp + _shadow_space + _reg_size] ; Arg2: pointer to stack frame.
     call HandleException
     add rsp, _shadow_space      ; Deallocate shadow space.
     pop_regs                    ; Restore registers.

--- a/kernel/src/acpi/acpi.cpp
+++ b/kernel/src/acpi/acpi.cpp
@@ -3,50 +3,22 @@
 #include <internal/formats.hpp>
 #include "trace_framework.hpp"
 
-// TODO
-#include <include/multiboot2/multiboot2.h>
-#include <include/multiboot2/multiboot_info.hpp>
-
 /* External includes */
 #include <uacpi/event.h>
 #include <uacpi/uacpi.h>
-
-static Multiboot::TagNewAcpi *FindAcpiTag(u64 multiboot_info_addr)
-{
-    // TODO: 1. Multiboot Tags should be in both the arch and the kernel, so maybe move to libk?
-    // TODO: 2. This should probably recieve a MultibootInfo object instead of an address.
-    DEBUG_INFO_GENERAL("Finding ACPI tag in multiboot tags...");
-    Multiboot::MultibootInfo multiboot_info(multiboot_info_addr);
-
-    auto *new_acpi_tag = multiboot_info.FindTag<Multiboot::TagNewAcpi>();
-
-    if (new_acpi_tag == nullptr) {
-        TRACE_WARN_GENERAL("ACPI2.0 tag not found in multiboot tags, trying ACPI1.0 tag...");
-        auto *old_acpi_tag = multiboot_info.FindTag<Multiboot::TagOldAcpi>();
-
-        new_acpi_tag = reinterpret_cast<Multiboot::TagNewAcpi *>(old_acpi_tag);
-    }
-
-    return new_acpi_tag;
-}
 
 int ACPI::ACPIController::Init(const BootArguments &args)
 {
     TODO_WHEN_VMEM_WORKS
     DEBUG_INFO_GENERAL("ACPI initialization...");
 
-    DEBUG_INFO_GENERAL("Finding RSDP...");
-    auto *acpi_tag = FindAcpiTag(Mem::PtrToUptr(args.multiboot_info));
+    DEBUG_INFO_GENERAL("Getting RSDP from boot arguments...");
     R_ASSERT_NOT_NULL(
-        acpi_tag, "ACPI tag not found in multiboot tags, only platforms with ACPI supported..."
+        args.rsdp,
+        "RSDP address not provided in boot arguments, only platforms with ACPI supported..."
     );
 
-    DEBUG_INFO_GENERAL(
-        "ACPI tag found at 0x%016llX, size: %sB", reinterpret_cast<u64>(acpi_tag),
-        FormatMetricUint(acpi_tag->size)
-    );
-
-    RsdpAddress_ = reinterpret_cast<void *>(acpi_tag->rsdp);
+    RsdpAddress_ = args.rsdp;
     DEBUG_INFO_GENERAL("RSDP address: 0x%016p", RsdpAddress_);
 
     /* Load all tables, bring the event subsystem online, and enter ACPI mode */

--- a/kernel/src/acpi/acpi.hpp
+++ b/kernel/src/acpi/acpi.hpp
@@ -57,14 +57,14 @@ class ACPIController final : public hal::AcpiController
     // Getters
     // ------------------------------
 
-    FORCE_INLINE_F void *GetRsdpAddress() const { return RsdpAddress_; }
+    FORCE_INLINE_F Mem::PPtr<void> GetRsdpAddress() const { return RsdpAddress_; }
 
     // ------------------------------
     // Class fields
     // ------------------------------
 
     private:
-    void *RsdpAddress_{};
+    Mem::PPtr<void> RsdpAddress_{};
 };
 
 //////////////////////////////

--- a/kernel/src/acpi/osl.cpp
+++ b/kernel/src/acpi/osl.cpp
@@ -223,7 +223,7 @@ uacpi_cpu_flags uacpi_kernel_lock_spinlock(uacpi_handle handle)
 {
     ASSERT_NOT_NULL(handle);
 
-    const auto spinlock = static_cast<Spinlock *>(handle);
+    auto *const spinlock = static_cast<Spinlock *>(handle);
     spinlock->Lock();
 
     return 0;
@@ -233,7 +233,7 @@ void uacpi_kernel_unlock_spinlock(uacpi_handle handle, uacpi_cpu_flags)
 {
     ASSERT_NOT_NULL(handle);
 
-    const auto spinlock = static_cast<Spinlock *>(handle);
+    auto *const spinlock = static_cast<Spinlock *>(handle);
     spinlock->Unlock();
 }
 
@@ -242,7 +242,7 @@ TODO_WHEN_MUTEX_IMPLEMENTED
 uacpi_status uacpi_kernel_acquire_mutex(uacpi_handle handle, uacpi_u16)
 {
     ASSERT_NOT_NULL(handle);
-    const auto spinlock = static_cast<Spinlock *>(handle);
+    auto *const spinlock = static_cast<Spinlock *>(handle);
     spinlock->Lock();
 
     return UACPI_STATUS_OK;
@@ -251,7 +251,7 @@ uacpi_status uacpi_kernel_acquire_mutex(uacpi_handle handle, uacpi_u16)
 void uacpi_kernel_release_mutex(uacpi_handle handle)
 {
     ASSERT_NOT_NULL(handle);
-    const auto spinlock = static_cast<Spinlock *>(handle);
+    auto *const spinlock = static_cast<Spinlock *>(handle);
     spinlock->Unlock();
 }
 

--- a/kernel/src/boot_args.cpp
+++ b/kernel/src/boot_args.cpp
@@ -48,6 +48,7 @@ BootArguments SanitizeBootArgs(const hal::RawBootArguments &raw_args)
         .multiboot_info    = UptrToPtr<void>(raw_args.multiboot_info_phys_addr),
         .fb_args           = fb_args,
         .ramdisk_args      = ramdisk_args,
+        .rsdp              = UptrToPtr<void>(raw_args.acpi_rsdp_phys_addr),
     };
 
     DEBUG_INFO_BOOT("Sanitized boot arguments:");
@@ -61,6 +62,7 @@ BootArguments SanitizeBootArgs(const hal::RawBootArguments &raw_args)
         "    mem_bitmap:         %p\n"
         "    total_page_frames:  %zu\n"
         "    multiboot_info:     %p\n"
+        "    rsdp:               %p\n"
         "  Framebuffer Arguments:\n"
         "    base_address:       %p\n"
         "    width:              %u\n"
@@ -76,7 +78,7 @@ BootArguments SanitizeBootArgs(const hal::RawBootArguments &raw_args)
         sanitized_k_args.kernel_start, sanitized_k_args.kernel_end,
         sanitized_k_args.ramdisk_args.start, sanitized_k_args.ramdisk_args.end,
         sanitized_k_args.root_page_table, sanitized_k_args.mem_bitmap,
-        sanitized_k_args.total_page_frames, sanitized_k_args.multiboot_info,
+        sanitized_k_args.total_page_frames, sanitized_k_args.multiboot_info, sanitized_k_args.rsdp,
         sanitized_k_args.fb_args.base_address, sanitized_k_args.fb_args.width,
         sanitized_k_args.fb_args.height, sanitized_k_args.fb_args.pitch,
         sanitized_k_args.fb_args.bpp, sanitized_k_args.fb_args.red_pos,

--- a/kernel/src/boot_args.hpp
+++ b/kernel/src/boot_args.hpp
@@ -32,6 +32,7 @@ struct BootArguments {
     Mem::PPtr<void> multiboot_info;
     FramebufferArgs fb_args;
     RamdiskArgs ramdisk_args;
+    Mem::PPtr<void> rsdp;
 };
 
 BootArguments SanitizeBootArgs(const hal::RawBootArguments &raw_args);

--- a/kernel/src/hal/api/boot_args.hpp
+++ b/kernel/src/hal/api/boot_args.hpp
@@ -36,6 +36,9 @@ struct RawBootArgumentsAPI {
     // Ramdisk
     u64 ramdisk_start;
     u64 ramdisk_end;
+
+    // ACPI
+    u64 acpi_rsdp_phys_addr;
 };
 }  // namespace arch
 

--- a/kernel/src/init.cpp
+++ b/kernel/src/init.cpp
@@ -41,18 +41,18 @@ void KernelInit(const hal::RawBootArguments &raw_args)
     GlobalStateModule::Init();
 
     /* Initialize ACPI */
-    // HardwareModule::Get().GetACPIController().Init(args);
+    HardwareModule::Get().GetACPIController().Init(args);
 
     /* Extract all necessary data from ACPI tables */
-    // HardwareModule::Get().GetACPIController().ParseTables();
+    HardwareModule::Get().GetACPIController().ParseTables();
 
     /* Allow hardware to fully initialise interrupt system */
-    // HardwareModule::Get().GetInterrupts().Init();
+    HardwareModule::Get().GetInterrupts().Init();
 
     /* Setup core local data */
 
     /* Initialize the timing system */
-    // TimingModule::Init();
+    TimingModule::Init();
 
     MemoryModule::Get().RegisterPageFault(HardwareModule::Get());
 


### PR DESCRIPTION
## Problem
Bug in irq error wrapper callback, having offset to error struct wrong by 8-bytes
also bug in timing module which doesnt initialize numerator and denumerator

Also multiboot related code (`x86_64` specific) present in generic kernel. Moved the related logic to bootloader

## Solution
Fixed those bugs and uncommented uacpi & timing related code