### PR TITLE
Kryczkal/keyboard

### DIFF
--- a/kernel/arch/x86_64/CMakeLists.txt
+++ b/kernel/arch/x86_64/CMakeLists.txt
@@ -58,7 +58,7 @@ alkos_register_runtime_environment(
     QEMU_COMMAND
         "qemu-system-x86_64"
     QEMU_NORMAL_FLAGS
-        "-serial stdio -enable-kvm -cpu max -display default,show-cursor=on -m 4G -smp sockets=1,cores=4,threads=1"
+    "-serial stdio -enable-kvm -cpu max -display default,show-cursor=on -k en-us -m 4G -smp sockets=1,cores=4,threads=1"
     QEMU_TEST_FLAGS
         "-serial stdio -enable-kvm -cpu max -display none -m 4G -smp sockets=1,cores=4,threads=1"
     MODULES

--- a/kernel/arch/x86_64/src/drivers/apic/io_apic.cpp
+++ b/kernel/arch/x86_64/src/drivers/apic/io_apic.cpp
@@ -3,6 +3,7 @@
 
 #include <bit.hpp>
 #include <todo.hpp>
+
 #include "interrupts/idt.hpp"
 #include "trace_framework.hpp"
 
@@ -54,15 +55,30 @@ IoApic::IoApic(const u8 id, const u32 address, const u32 gsi_base)
 
 void IoApic::PrepareDefaultConfig() const
 {
+    // Get the APIC ID of the running processor (BSP) to route interrupts to it
+    const u32 bsp_apic_id = LocalApic::GetCoreId();
+
     for (u32 idx = 0; idx < num_entries_; ++idx) {
         auto reg_low = ReadLowerTableRegister(idx);
+        // Prepare the Destination Register
+        HigherTableRegister reg_high{};
+        reg_high.destination = bsp_apic_id;
 
-        /* Note: vector not initialized */
+        /* Set defaults */
         reg_low.delivery_mode    = LowerTableRegister::DeliveryMode::kFixed;
         reg_low.destination_mode = LowerTableRegister::DestinationMode::kPhysical;
         reg_low.pin_polarity     = LowerTableRegister::PinPolarity::kActiveHigh;
         reg_low.trigger_mode     = LowerTableRegister::TriggerMode::kEdge;
-        reg_low.mask             = LowerTableRegister::EnabledFlag::kEnabled;
+
+        /* Map ISA interrupts (GSI 0-15) to IDT vectors */
+        const u32 current_gsi = gsi_base_ + idx;
+        if (current_gsi < 16) {
+            reg_low.vector = kIrq1Offset + current_gsi;
+            reg_low.mask   = LowerTableRegister::EnabledFlag::kEnabled;
+        } else {
+            reg_low.vector = 0;
+            reg_low.mask   = LowerTableRegister::EnabledFlag::kDisabled;
+        }
 
         WriteLowerTableRegister(idx, reg_low);
     }

--- a/kernel/arch/x86_64/src/drivers/apic/io_apic.hpp
+++ b/kernel/arch/x86_64/src/drivers/apic/io_apic.hpp
@@ -178,6 +178,13 @@ class IoApic final
         WriteRegister(IoApicTableReg(reg_idx), ToRawRegister(reg_low));
     }
 
+    FORCE_INLINE_F void WriteHigherTableRegister(
+        const u32 reg_idx, const HigherTableRegister &reg_high
+    ) const
+    {
+        WriteRegister(IoApicTableReg(reg_idx) + 1, ToRawRegister(reg_high));
+    }
+
     // ------------------------------
     // Status and Configuration Methods
     // ------------------------------

--- a/kernel/arch/x86_64/src/drivers/apic/local_apic.cpp
+++ b/kernel/arch/x86_64/src/drivers/apic/local_apic.cpp
@@ -90,6 +90,7 @@ void LocalApic::Enable()
     reg.vector  = kSpuriousVector;
 
     WriteRegister(kSpuriousInterruptRegRW, reg);
+    WriteRegister(kTaskPriorityRegRW, 0);
 
     DEBUG_INFO_INTERRUPTS("Local APIC enabled...");
 }

--- a/kernel/arch/x86_64/src/hal/impl/acpi_controller.cpp
+++ b/kernel/arch/x86_64/src/hal/impl/acpi_controller.cpp
@@ -96,16 +96,20 @@ static void PrepareIoApic_(MadtTable &table)
     DEBUG_INFO_INTERRUPTS("Detected %lu I/O APIC devices...", num_apic);
 
     table.ForEachTableEntry([](const acpi_entry_hdr *entry) {
-        const auto table_ptr = ACPI::TryToAccessTheTable<acpi_madt_ioapic>(entry);
+        const auto *const table_ptr = ACPI::TryToAccessTheTable<acpi_madt_ioapic>(entry);
 
         if (!table_ptr) {
             return;
         }
 
-        HardwareModule::Get().GetInterrupts().GetIoApicTable().PushEmplace(
+        auto &io_apic_table = HardwareModule::Get().GetInterrupts().GetIoApicTable();
+        io_apic_table.PushEmplace(
             static_cast<u8>(table_ptr->id), static_cast<u32>(table_ptr->address),
             static_cast<u32>(table_ptr->gsi_base)
         );
+
+        // Initialize default configuration immediately so overrides can apply on top later
+        io_apic_table[io_apic_table.Size() - 1].PrepareDefaultConfig();
     });
 }
 

--- a/kernel/arch/x86_64/src/hal/impl/interrupts.cpp
+++ b/kernel/arch/x86_64/src/hal/impl/interrupts.cpp
@@ -21,13 +21,10 @@ void Interrupts::Init()
     /* Disable PIC unit */
     Pic8259Disable();
 
-    /* Enable IO apics */
-    for (IoApic &io_apic : GetIoApicTable()) {
-        io_apic.PrepareDefaultConfig();
-    }
-
     /* Replace first stage PIC with new APIC chip on startup Core */
     local_apic_.Enable();
+
+    ReplacePicDriverWithLapic_();
 
     tsc::Initialize();
 

--- a/kernel/src/drivers/input/keyboard.hpp
+++ b/kernel/src/drivers/input/keyboard.hpp
@@ -1,0 +1,61 @@
+#ifndef KERNEL_SRC_DRIVERS_INPUT_KEYBOARD_HPP_
+#define KERNEL_SRC_DRIVERS_INPUT_KEYBOARD_HPP_
+
+#include "io/pipe.hpp"
+#include "io/stream.hpp"
+
+namespace Drivers::Input
+{
+
+/**
+ * @brief Abstract Keyboard Driver Base Class.
+ *
+ * This class decouples the mechanism of receiving keystrokes (Hardware Interrupts)
+ * from the mechanism of consuming them (Shell/User-space).
+ *
+ */
+class Keyboard : public IO::IReader
+{
+    public:
+    static constexpr size_t kKeyBufferSize = 128;
+
+    virtual ~Keyboard() = default;
+
+    // ------------------------------
+    // IO::IReader Implementation
+    // ------------------------------
+
+    /**
+     * @brief Reads buffered characters from the keyboard.
+     * @param buffer Destination buffer.
+     * @return Number of bytes read or Error::Retry if empty.
+     */
+    IO::IoResult Read(std::span<byte> buffer) override { return pipe_.Read(buffer); }
+
+    // ------------------------------
+    // Protected Interface for Drivers
+    // ------------------------------
+
+    protected:
+    /**
+     * @brief Pushes a decoded character into the internal buffer.
+     * This method is intended to be called by derived classes (Drivers)
+     * typically from an Interrupt Service Routine context.
+     *
+     * @param c The decoded ASCII character.
+     */
+    void PushKey(char c)
+    {
+        byte b = static_cast<byte>(c);
+        // If full drop the keystroke
+        (void)pipe_.Write(std::span<const byte>(&b, 1));
+    }
+
+    private:
+    // Lock-free pipe enables IRQ-Main communication
+    IO::Pipe<kKeyBufferSize> pipe_;
+};
+
+}  // namespace Drivers::Input
+
+#endif  // KERNEL_SRC_DRIVERS_INPUT_KEYBOARD_HPP_

--- a/kernel/src/drivers/input/ps2_keyboard.cpp
+++ b/kernel/src/drivers/input/ps2_keyboard.cpp
@@ -40,33 +40,31 @@ void Ps2Keyboard::Init()
 {
     TRACE_INFO_GENERAL("Initializing PS/2 Keyboard...");
 
-    // Disable Devices (prevent IRQs while we configure)
-    status_reg_.Write<u8>(kCmdDisableKeyboard);  // Disable Keyboard
-    status_reg_.Write<u8>(kCmdDisableMouse);     // Disable Mouse
+    // prevent IRQs while we configure
+    status_reg_.Write<u8>(kCmdDisableKeyboard);
+    status_reg_.Write<u8>(kCmdDisableMouse);
 
-    // Flush Output Buffer (Read garbage)
+    // Flush Output Buffer
     while ((status_reg_.Read<u8>() & kStatusOutputBufferFull) != 0) {
         (void)data_reg_.Read<u8>();
     }
 
     // Set Controller Configuration
-    status_reg_.Write<u8>(kCmdReadConfig);  // Read Config
+    status_reg_.Write<u8>(kCmdReadConfig);
     while ((status_reg_.Read<u8>() & kStatusOutputBufferFull) == 0);
     u8 config = data_reg_.Read<u8>();
 
-    config |= kConfigIrq1Enable;        // Enable IRQ1
-    config |= kConfigTranslation;       // Enable Translation
-    config &= ~kConfigDisableKeyboard;  // Clear Disable Keyboard bit
+    config |= kConfigIrq1Enable;
+    config |= kConfigTranslation;
+    config &= ~kConfigDisableKeyboard;
 
-    status_reg_.Write<u8>(kCmdWriteConfig);  // Write Config
+    status_reg_.Write<u8>(kCmdWriteConfig);
     while ((status_reg_.Read<u8>() & kStatusInputBufferFull) != 0);
     data_reg_.Write<u8>(config);
 
-    // Enable Keyboard Interface
     status_reg_.Write<u8>(kCmdEnableKeyboard);
 
-    // Reset Keyboard Device (Send 0xFF)
-    while ((status_reg_.Read<u8>() & kStatusInputBufferFull) != 0);  // Wait for input empty
+    while ((status_reg_.Read<u8>() & kStatusInputBufferFull) != 0);
     data_reg_.Write<u8>(kCmdResetDevice);
 
     // Wait for Reset Response (ACK 0xFA + Success 0xAA)
@@ -87,11 +85,9 @@ void Ps2Keyboard::Init()
         TRACE_WARN_GENERAL("PS/2 Reset Timed Out - Keyboard might be unresponsive");
     }
 
-    // Enable Scanning (Send 0xF4)
     while ((status_reg_.Read<u8>() & kStatusInputBufferFull) != 0);
     data_reg_.Write<u8>(kCmdEnableScanning);
 
-    // Wait for ACK (0xFA)
     timeout = kResetTimeout;
     while (timeout > 0) {
         if ((status_reg_.Read<u8>() & kStatusOutputBufferFull) != 0) {
@@ -112,22 +108,18 @@ void Ps2Keyboard::OnInterrupt()
     TRACE_INFO_HARDWARE("PS/2 Interrupt fired");
     const u8 status = status_reg_.Read<u8>();
 
-    // Check Output Buffer Full (Bit 0)
     if ((status & kStatusOutputBufferFull) != 0) {
         const u8 scancode = data_reg_.Read<u8>();
 
-        // Handle Extended byte (0xE0)
         // This indicates the next byte is part of an extended sequence (e.g., arrow keys)
         if (scancode == kScancodeExtendedPrefix) {
             is_e0_prefix_ = true;
             return;
         }
 
-        // Check for Break Code (Key Release). Bit 7 is set.
         if ((scancode & kScancodeBreakMask) != 0) {
             const u8 released_code = scancode & ~kScancodeBreakMask;
 
-            // Handle Shift Release (Left: 0x2A, Right: 0x36)
             if (released_code == kScancodeLeftShift || released_code == kScancodeRightShift) {
                 shift_pressed_ = false;
             }
@@ -138,7 +130,7 @@ void Ps2Keyboard::OnInterrupt()
         }
 
         // Handle Make Code (Key Press)
-        if (scancode == kScancodeLeftShift || scancode == kScancodeRightShift) {  // Shifts
+        if (scancode == kScancodeLeftShift || scancode == kScancodeRightShift) {
             shift_pressed_ = true;
         } else if (scancode == kScancodeCapsLock) {  // Caps Lock
             caps_lock_ = !caps_lock_;

--- a/kernel/src/drivers/input/ps2_keyboard.cpp
+++ b/kernel/src/drivers/input/ps2_keyboard.cpp
@@ -1,0 +1,114 @@
+#include "drivers/input/ps2_keyboard.hpp"
+
+namespace Drivers::Input
+{
+
+// ----------------------------------------------------------------------------
+// Scancode Maps (Set 1)
+// ----------------------------------------------------------------------------
+
+static constexpr char kScancodeMap[128] = {
+    0,   27,  '1', '2', '3', '4', '5',  '6', '7', '8',  '9', '0',  '-', '=', '\b', '\t', 'q',
+    'w', 'e', 'r', 't', 'y', 'u', 'i',  'o', 'p', '[',  ']', '\n', 0,   'a', 's',  'd',  'f',
+    'g', 'h', 'j', 'k', 'l', ';', '\'', '`', 0,   '\\', 'z', 'x',  'c', 'v', 'b',  'n',  'm',
+    ',', '.', '/', 0,   '*', 0,   ' ',  0,   0,   0,    0,   0,    0,   0,   0,    0,    0,
+    0,   0,   0,   0,   0,   0,   0,    0,   0,   0,    0,   0,    0,   0,   0,    0,    0,
+    0,   0,   0,   0,   0,   0,   0,    0,   0,   0,    0,   0,    0,   0,   0,    0,    0,
+    // F11, F12 (mapped to 0 here)
+};
+
+static constexpr char kScancodeMapShift[128] = {
+    0,   27,  '!', '@', '#', '$', '%', '^', '&', '*', '(', ')',  '_', '+', '\b', '\t', 'Q',
+    'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P', '{', '}', '\n', 0,   'A', 'S',  'D',  'F',
+    'G', 'H', 'J', 'K', 'L', ':', '"', '~', 0,   '|', 'Z', 'X',  'C', 'V', 'B',  'N',  'M',
+    '<', '>', '?', 0,   '*', 0,   ' ', 0,   0,   0,   0,   0,    0,   0,   0,    0,    0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,    0,   0,   0,    0,    0,
+    0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,    0,   0,   0,    0,    0,
+};
+
+// ----------------------------------------------------------------------------
+// Implementation
+// ----------------------------------------------------------------------------
+
+Ps2Keyboard::Ps2Keyboard(size_t data_addr, size_t status_addr)
+    : data_reg_(data_addr), status_reg_(status_addr)
+{
+}
+
+void Ps2Keyboard::Init()
+{
+    // Drain any pending data in the controller's buffer to start clean.
+    while ((status_reg_.Read<u8>() & 1) != 0) {
+        (void)data_reg_.Read<u8>();
+    }
+}
+
+void Ps2Keyboard::OnInterrupt()
+{
+    const u8 status = status_reg_.Read<u8>();
+
+    // Check Output Buffer Full (Bit 0)
+    if ((status & 0x01) != 0) {
+        const u8 scancode = data_reg_.Read<u8>();
+
+        // Handle Extended byte (0xE0)
+        // This indicates the next byte is part of an extended sequence (e.g., arrow keys)
+        if (scancode == 0xE0) {
+            is_e0_prefix_ = true;
+            return;
+        }
+
+        // Check for Break Code (Key Release). Bit 7 is set.
+        if ((scancode & 0x80) != 0) {
+            const u8 released_code = scancode & 0x7F;
+
+            // Handle Shift Release (Left: 0x2A, Right: 0x36)
+            if (released_code == 0x2A || released_code == 0x36) {
+                shift_pressed_ = false;
+            }
+
+            // Reset prefix on key release as well
+            is_e0_prefix_ = false;
+            return;
+        }
+
+        // Handle Make Code (Key Press)
+        if (scancode == 0x2A || scancode == 0x36) {  // Shifts
+            shift_pressed_ = true;
+        } else if (scancode == 0x3A) {  // Caps Lock
+            caps_lock_ = !caps_lock_;
+        } else {
+            // Translate and push regular characters
+            const char c = TranslateScancode(scancode);
+            if (c != 0) {
+                PushKey(c);
+            }
+        }
+
+        is_e0_prefix_ = false;
+    }
+}
+
+char Ps2Keyboard::TranslateScancode(u8 scancode)
+{
+    if (scancode > 127) {
+        return 0;
+    }
+
+    char c = kScancodeMap[scancode];
+    if (shift_pressed_) {
+        c = kScancodeMapShift[scancode];
+    }
+
+    if (caps_lock_) {
+        if (c >= 'a' && c <= 'z') {
+            c -= 32;
+        } else if (c >= 'A' && c <= 'Z') {
+            c += 32;
+        }
+    }
+
+    return c;
+}
+
+}  // namespace Drivers::Input

--- a/kernel/src/drivers/input/ps2_keyboard.cpp
+++ b/kernel/src/drivers/input/ps2_keyboard.cpp
@@ -1,4 +1,5 @@
 #include "drivers/input/ps2_keyboard.hpp"
+#include "trace_framework.hpp"
 
 namespace Drivers::Input
 {
@@ -37,14 +38,78 @@ Ps2Keyboard::Ps2Keyboard(size_t data_addr, size_t status_addr)
 
 void Ps2Keyboard::Init()
 {
-    // Drain any pending data in the controller's buffer to start clean.
+    TRACE_INFO_GENERAL("Initializing PS/2 Keyboard...");
+
+    // 1. Disable Devices (prevent IRQs while we configure)
+    status_reg_.Write<u8>(0xAD);  // Disable Keyboard
+    status_reg_.Write<u8>(0xA7);  // Disable Mouse
+
+    // 2. Flush Output Buffer (Read garbage)
     while ((status_reg_.Read<u8>() & 1) != 0) {
         (void)data_reg_.Read<u8>();
     }
+
+    // 3. Set Controller Configuration
+    status_reg_.Write<u8>(0x20);  // Read Config
+    while ((status_reg_.Read<u8>() & 1) == 0);
+    u8 config = data_reg_.Read<u8>();
+
+    config |= 0x01;     // Enable IRQ1
+    config |= 0x40;     // Enable Translation
+    config &= ~(0x10);  // Clear Disable Keyboard bit
+
+    status_reg_.Write<u8>(0x60);  // Write Config
+    while ((status_reg_.Read<u8>() & 2) != 0);
+    data_reg_.Write<u8>(config);
+
+    // 4. Enable Keyboard Interface
+    status_reg_.Write<u8>(0xAE);
+
+    // 5. Reset Keyboard Device (Send 0xFF)
+    // This ensures the keyboard is in a known state and clears its internal buffer
+    while ((status_reg_.Read<u8>() & 2) != 0);  // Wait for input empty
+    data_reg_.Write<u8>(0xFF);
+
+    // 6. Wait for Reset Response (ACK 0xFA + Success 0xAA)
+    // We must consume these bytes so they don't stick the IRQ line High!
+    int bytes_expected = 2;
+    int timeout        = 1000000;
+    while (bytes_expected > 0 && timeout > 0) {
+        u8 status = status_reg_.Read<u8>();
+        if (status & 1) {
+            u8 byte = data_reg_.Read<u8>();
+            TRACE_INFO_GENERAL("PS/2 Init: Consumed byte 0x%02x", byte);
+            bytes_expected--;
+        }
+        timeout--;
+    }
+
+    if (timeout == 0) {
+        TRACE_WARN_GENERAL("PS/2 Reset Timed Out - Keyboard might be unresponsive");
+    }
+
+    // 7. Enable Scanning (Send 0xF4)
+    while ((status_reg_.Read<u8>() & 2) != 0);
+    data_reg_.Write<u8>(0xF4);
+
+    // 8. Wait for ACK (0xFA)
+    timeout = 1000000;
+    while (timeout > 0) {
+        if (status_reg_.Read<u8>() & 1) {
+            u8 byte = data_reg_.Read<u8>();
+            if (byte == 0xFA)
+                break;
+        }
+        timeout--;
+    }
+
+    TRACE_INFO_GENERAL("PS/2 Keyboard Initialized & Drained");
+    trace::DumpAllBuffersOnFailure();
 }
 
 void Ps2Keyboard::OnInterrupt()
 {
+    DEBUG_INFO_GENERAL("PS/2 Interrupt fired!");
     const u8 status = status_reg_.Read<u8>();
 
     // Check Output Buffer Full (Bit 0)

--- a/kernel/src/drivers/input/ps2_keyboard.cpp
+++ b/kernel/src/drivers/input/ps2_keyboard.cpp
@@ -40,43 +40,42 @@ void Ps2Keyboard::Init()
 {
     TRACE_INFO_GENERAL("Initializing PS/2 Keyboard...");
 
-    // 1. Disable Devices (prevent IRQs while we configure)
-    status_reg_.Write<u8>(0xAD);  // Disable Keyboard
-    status_reg_.Write<u8>(0xA7);  // Disable Mouse
+    // Disable Devices (prevent IRQs while we configure)
+    status_reg_.Write<u8>(kCmdDisableKeyboard);  // Disable Keyboard
+    status_reg_.Write<u8>(kCmdDisableMouse);     // Disable Mouse
 
-    // 2. Flush Output Buffer (Read garbage)
-    while ((status_reg_.Read<u8>() & 1) != 0) {
+    // Flush Output Buffer (Read garbage)
+    while ((status_reg_.Read<u8>() & kStatusOutputBufferFull) != 0) {
         (void)data_reg_.Read<u8>();
     }
 
-    // 3. Set Controller Configuration
-    status_reg_.Write<u8>(0x20);  // Read Config
-    while ((status_reg_.Read<u8>() & 1) == 0);
+    // Set Controller Configuration
+    status_reg_.Write<u8>(kCmdReadConfig);  // Read Config
+    while ((status_reg_.Read<u8>() & kStatusOutputBufferFull) == 0);
     u8 config = data_reg_.Read<u8>();
 
-    config |= 0x01;     // Enable IRQ1
-    config |= 0x40;     // Enable Translation
-    config &= ~(0x10);  // Clear Disable Keyboard bit
+    config |= kConfigIrq1Enable;        // Enable IRQ1
+    config |= kConfigTranslation;       // Enable Translation
+    config &= ~kConfigDisableKeyboard;  // Clear Disable Keyboard bit
 
-    status_reg_.Write<u8>(0x60);  // Write Config
-    while ((status_reg_.Read<u8>() & 2) != 0);
+    status_reg_.Write<u8>(kCmdWriteConfig);  // Write Config
+    while ((status_reg_.Read<u8>() & kStatusInputBufferFull) != 0);
     data_reg_.Write<u8>(config);
 
-    // 4. Enable Keyboard Interface
-    status_reg_.Write<u8>(0xAE);
+    // Enable Keyboard Interface
+    status_reg_.Write<u8>(kCmdEnableKeyboard);
 
-    // 5. Reset Keyboard Device (Send 0xFF)
-    // This ensures the keyboard is in a known state and clears its internal buffer
-    while ((status_reg_.Read<u8>() & 2) != 0);  // Wait for input empty
-    data_reg_.Write<u8>(0xFF);
+    // Reset Keyboard Device (Send 0xFF)
+    while ((status_reg_.Read<u8>() & kStatusInputBufferFull) != 0);  // Wait for input empty
+    data_reg_.Write<u8>(kCmdResetDevice);
 
-    // 6. Wait for Reset Response (ACK 0xFA + Success 0xAA)
-    // We must consume these bytes so they don't stick the IRQ line High!
+    // Wait for Reset Response (ACK 0xFA + Success 0xAA)
+    // We must consume these bytes so they don't stick the IRQ line as High
     int bytes_expected = 2;
-    int timeout        = 1000000;
+    int timeout        = kResetTimeout;
     while (bytes_expected > 0 && timeout > 0) {
         u8 status = status_reg_.Read<u8>();
-        if (status & 1) {
+        if ((status & kStatusOutputBufferFull) != 0) {
             u8 byte = data_reg_.Read<u8>();
             TRACE_INFO_GENERAL("PS/2 Init: Consumed byte 0x%02x", byte);
             bytes_expected--;
@@ -88,47 +87,48 @@ void Ps2Keyboard::Init()
         TRACE_WARN_GENERAL("PS/2 Reset Timed Out - Keyboard might be unresponsive");
     }
 
-    // 7. Enable Scanning (Send 0xF4)
-    while ((status_reg_.Read<u8>() & 2) != 0);
-    data_reg_.Write<u8>(0xF4);
+    // Enable Scanning (Send 0xF4)
+    while ((status_reg_.Read<u8>() & kStatusInputBufferFull) != 0);
+    data_reg_.Write<u8>(kCmdEnableScanning);
 
-    // 8. Wait for ACK (0xFA)
-    timeout = 1000000;
+    // Wait for ACK (0xFA)
+    timeout = kResetTimeout;
     while (timeout > 0) {
-        if (status_reg_.Read<u8>() & 1) {
+        if ((status_reg_.Read<u8>() & kStatusOutputBufferFull) != 0) {
             u8 byte = data_reg_.Read<u8>();
-            if (byte == 0xFA)
+            if (byte == kResponseAck) {
                 break;
+            }
         }
         timeout--;
     }
 
     TRACE_INFO_GENERAL("PS/2 Keyboard Initialized & Drained");
-    trace::DumpAllBuffersOnFailure();
+    trace::Flush();
 }
 
 void Ps2Keyboard::OnInterrupt()
 {
-    DEBUG_INFO_GENERAL("PS/2 Interrupt fired!");
+    TRACE_INFO_HARDWARE("PS/2 Interrupt fired");
     const u8 status = status_reg_.Read<u8>();
 
     // Check Output Buffer Full (Bit 0)
-    if ((status & 0x01) != 0) {
+    if ((status & kStatusOutputBufferFull) != 0) {
         const u8 scancode = data_reg_.Read<u8>();
 
         // Handle Extended byte (0xE0)
         // This indicates the next byte is part of an extended sequence (e.g., arrow keys)
-        if (scancode == 0xE0) {
+        if (scancode == kScancodeExtendedPrefix) {
             is_e0_prefix_ = true;
             return;
         }
 
         // Check for Break Code (Key Release). Bit 7 is set.
-        if ((scancode & 0x80) != 0) {
-            const u8 released_code = scancode & 0x7F;
+        if ((scancode & kScancodeBreakMask) != 0) {
+            const u8 released_code = scancode & ~kScancodeBreakMask;
 
             // Handle Shift Release (Left: 0x2A, Right: 0x36)
-            if (released_code == 0x2A || released_code == 0x36) {
+            if (released_code == kScancodeLeftShift || released_code == kScancodeRightShift) {
                 shift_pressed_ = false;
             }
 
@@ -138,9 +138,9 @@ void Ps2Keyboard::OnInterrupt()
         }
 
         // Handle Make Code (Key Press)
-        if (scancode == 0x2A || scancode == 0x36) {  // Shifts
+        if (scancode == kScancodeLeftShift || scancode == kScancodeRightShift) {  // Shifts
             shift_pressed_ = true;
-        } else if (scancode == 0x3A) {  // Caps Lock
+        } else if (scancode == kScancodeCapsLock) {  // Caps Lock
             caps_lock_ = !caps_lock_;
         } else {
             // Translate and push regular characters

--- a/kernel/src/drivers/input/ps2_keyboard.hpp
+++ b/kernel/src/drivers/input/ps2_keyboard.hpp
@@ -18,6 +18,39 @@ class Ps2Keyboard final : public Keyboard
     static constexpr size_t kDefaultDataPort   = 0x60;
     static constexpr size_t kDefaultStatusPort = 0x64;
 
+    // PS/2 Controller Commands
+    static constexpr u8 kCmdDisableKeyboard = 0xAD;
+    static constexpr u8 kCmdDisableMouse    = 0xA7;
+    static constexpr u8 kCmdEnableKeyboard  = 0xAE;
+    static constexpr u8 kCmdReadConfig      = 0x20;
+    static constexpr u8 kCmdWriteConfig     = 0x60;
+
+    // PS/2 Keyboard Device Commands
+    static constexpr u8 kCmdResetDevice    = 0xFF;
+    static constexpr u8 kCmdEnableScanning = 0xF4;
+
+    // Status Register Bits
+    static constexpr u8 kStatusOutputBufferFull = 1 << 0;
+    static constexpr u8 kStatusInputBufferFull  = 1 << 1;
+
+    // Configuration Byte Bits
+    static constexpr u8 kConfigIrq1Enable      = 1 << 0;
+    static constexpr u8 kConfigDisableKeyboard = 1 << 4;
+    static constexpr u8 kConfigTranslation     = 1 << 6;
+
+    // Device Responses
+    static constexpr u8 kResponseAck          = 0xFA;
+    static constexpr u8 kResponseResetSuccess = 0xAA;
+
+    // Scancodes (Set 1)
+    static constexpr u8 kScancodeExtendedPrefix = 0xE0;
+    static constexpr u8 kScancodeBreakMask      = 0x80;
+    static constexpr u8 kScancodeLeftShift      = 0x2A;
+    static constexpr u8 kScancodeRightShift     = 0x36;
+    static constexpr u8 kScancodeCapsLock       = 0x3A;
+
+    static constexpr int kResetTimeout = 1000000;
+
     /**
      * @brief Construct a new Ps2 Keyboard driver.
      * @param data_addr I/O address of the data register.

--- a/kernel/src/drivers/input/ps2_keyboard.hpp
+++ b/kernel/src/drivers/input/ps2_keyboard.hpp
@@ -1,0 +1,57 @@
+#ifndef KERNEL_SRC_DRIVERS_INPUT_PS2_KEYBOARD_HPP_
+#define KERNEL_SRC_DRIVERS_INPUT_PS2_KEYBOARD_HPP_
+
+#include <drivers/input/keyboard.hpp>
+#include <io/register.hpp>
+#include <types.hpp>
+
+namespace Drivers::Input
+{
+
+/**
+ * @brief Driver for a Generic PS/2 Keyboard connected via an 8042 Controller.
+ */
+class Ps2Keyboard final : public Keyboard
+{
+    public:
+    // Standard 8042 Controller Ports
+    static constexpr size_t kDefaultDataPort   = 0x60;
+    static constexpr size_t kDefaultStatusPort = 0x64;
+
+    /**
+     * @brief Construct a new Ps2 Keyboard driver.
+     * @param data_addr I/O address of the data register.
+     * @param status_addr I/O address of the status/command register.
+     */
+    explicit Ps2Keyboard(
+        size_t data_addr = kDefaultDataPort, size_t status_addr = kDefaultStatusPort
+    );
+
+    /**
+     * @brief Initializes the driver and drains any pending garbage in the buffer.
+     */
+    void Init();
+
+    /**
+     * @brief Handle the interrupt request.
+     * Should be called by the architecture-specific ISR wrapper.
+     */
+    void OnInterrupt();
+
+    private:
+    // I/O Abstractions
+    IO::Register data_reg_;
+    IO::Register status_reg_;
+
+    // Translation State Machine
+    bool is_e0_prefix_{false};  // Processing an extended scancode?
+    bool shift_pressed_{false};
+    bool caps_lock_{false};
+
+    // Helpers
+    NODISCARD char TranslateScancode(u8 scancode);
+};
+
+}  // namespace Drivers::Input
+
+#endif  // KERNEL_SRC_DRIVERS_INPUT_PS2_KEYBOARD_HPP_

--- a/kernel/src/hardware.cpp
+++ b/kernel/src/hardware.cpp
@@ -1,8 +1,0 @@
-#include "modules/hardware.hpp"
-
-#include "trace_framework.hpp"
-
-internal::HardwareModule::HardwareModule() noexcept
-{
-    DEBUG_INFO_GENERAL("HardwareModule::HardwareModule()");
-}

--- a/kernel/src/init.cpp
+++ b/kernel/src/init.cpp
@@ -54,7 +54,9 @@ void KernelInit(const hal::RawBootArguments &raw_args)
     /* Initialize the timing system */
     TimingModule::Init();
 
+    // Register Interrupts
     MemoryModule::Get().RegisterPageFault(HardwareModule::Get());
+    HardwareModule::Get().RegisterInterruptHandlers();
 
     VfsModule::Init(args);
 

--- a/kernel/src/init.cpp
+++ b/kernel/src/init.cpp
@@ -54,11 +54,11 @@ void KernelInit(const hal::RawBootArguments &raw_args)
     /* Initialize the timing system */
     TimingModule::Init();
 
-    // Register Interrupts
-    MemoryModule::Get().RegisterPageFault(HardwareModule::Get());
-    HardwareModule::Get().RegisterInterruptHandlers();
-
     VfsModule::Init(args);
 
     VideoModule::Init(args, MemoryModule::Get().GetHeap());
+
+    // Register Interrupts
+    MemoryModule::Get().RegisterPageFault(HardwareModule::Get());
+    HardwareModule::Get().RegisterInterruptHandlers();
 }

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -67,8 +67,7 @@ extern void KernelInit(const hal::RawBootArguments &);
 static void KernelRun()
 {
     TRACE_INFO_GENERAL("Hello from AlkOS!");
-    trace::DumpAllBuffersOnFailure();
-    TODO_MMU_MINIMAL
+    trace::Flush();
 
     auto &video = VideoModule::Get();
     Graphics::Painter painter(video.GetScreen(), video.GetFormat());
@@ -79,34 +78,10 @@ static void KernelRun()
     }
 
     System::GraphicsConsole console(painter, font);
-
     System::Shell shell(console, HardwareModule::Get().GetPs2Keyboard());
 
     shell.Init();
     video.Flush();
-
-    // TRACE_INFO_GENERAL("Starting Polling Mode Debug...");
-
-    //     trace::DumpAllBuffersOnFailure();
-    // while (true) {
-    //     // Read Status Register
-    //     u8 status = arch::IoRead<u8>(0x64);
-    //
-    //     // Check Output Buffer Full (Bit 0)
-    //     if (status & 0x01) {
-    //         u8 scancode = arch::IoRead<u8>(0x60);
-    //         TRACE_INFO_GENERAL("POLLING: Got scancode 0x%02x", scancode);
-    //
-    //         // Pass to shell manually to see visual feedback
-    //         HardwareModule::Get().GetPs2Keyboard().OnInterrupt();
-    //     }
-    //
-    //     // Slow down the loop slightly to not flood logs if broken
-    //     for (volatile i32 i = 0; i < 100000; ++i) {}
-    //
-    //     video.Flush();
-    //     trace::DumpAllBuffersOnFailure();
-    // }
 
     while (true) {
         shell.Update();
@@ -114,7 +89,7 @@ static void KernelRun()
 
         for (volatile i32 i = 0; i < 10000; ++i) {
         }
-        trace::DumpAllBuffersOnFailure();
+        trace::Flush();
     }
 }
 

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -1,6 +1,5 @@
 #include <assert.h>
 #include <autogen/feature_flags.h>
-#include <time.h>
 #include <string.hpp>
 #include <test_module/test_module.hpp>
 #include "trace_framework.hpp"
@@ -11,56 +10,14 @@
 #include "graphics/font/psf2_font.hpp"
 #include "graphics/fonts/drdos8x8.hpp"
 #include "graphics/painter.hpp"
-#include "hal/terminal.hpp"
 #include "modules/hardware.hpp"
 #include "modules/video.hpp"
 #include "sys/shell.hpp"
 
-#include "boot_args.hpp"
 #include "drivers/apic/local_apic.hpp"
 #include "hal/boot_args.hpp"
-#include "io/register.hpp"  // For port I/O
-#include "mem/heap.hpp"
 #include "modules/hardware.hpp"
 #include "todo.hpp"
-
-void DebugKeyboardState()
-{
-    using namespace hal;
-
-    // 1. Check PS/2 Status Register (Port 0x64)
-    // Bit 0 = Output Buffer Full. If 1, data is waiting.
-    u8 status = arch::IoRead<u8>(0x64);
-    DEBUG_INFO_GENERAL("PS/2 Status: 0x%02x (OBF: %d)", status, status & 1);
-
-    // 2. Check Local APIC ID and ISR
-    // We want to see if the CPU thinks it's servicing an interrupt
-    auto &lapic = HardwareModule::Get().GetInterrupts().GetLocalApic();
-    u32 id      = lapic.ReadRegister(LocalApic::kIdRegRW);
-    u32 isr     = lapic.ReadRegister(0x110);  // ISR for vectors 32-63
-    u32 irr     = lapic.ReadRegister(0x210);  // IRR for vectors 32-63
-    DEBUG_INFO_GENERAL("LAPIC ID: %u, ISR[32-63]: 0x%08x, IRR[32-63]: 0x%08x", id >> 24, isr, irr);
-
-    // 3. Check IOAPIC Redirection Entry for IRQ 1
-    // Usually IOAPIC ID 0 is the one handling ISA IRQs.
-    // GSI 1 corresponds to the keyboard.
-    // We need to access the registers manually here for debug if no getter exists.
-    auto &ioapic_table = HardwareModule::Get().GetInterrupts().GetIoApicTable();
-    if (ioapic_table.Size() > 0) {
-        auto &ioapic = ioapic_table[0];  // Assuming first IOAPIC covers GSI 0-23
-
-        // Read entry 1 (keyboard)
-        // Redirection entries start at 0x10, 2 registers per entry (low/high)
-        auto low  = ioapic.ReadRegister(0x10 + (1 * 2));
-        auto high = ioapic.ReadRegister(0x10 + (1 * 2) + 1);
-
-        DEBUG_INFO_GENERAL("IOAPIC Redir[1] Low: 0x%08x, High: 0x%08x", low, high);
-        DEBUG_INFO_GENERAL("  -> Vector: 0x%02x", low & 0xFF);
-        DEBUG_INFO_GENERAL("  -> Masked: %d", (low >> 16) & 1);
-        DEBUG_INFO_GENERAL("  -> Trigger: %s", ((low >> 15) & 1) ? "Level" : "Edge");
-        DEBUG_INFO_GENERAL("  -> Dest: %u", (high >> 24));
-    }
-}
 
 extern void KernelInit(const hal::RawBootArguments &);
 
@@ -87,6 +44,7 @@ static void KernelRun()
         shell.Update();
         video.Flush();
 
+        // TODO: Replace with CpuHalt or smth like scheduler sleep.
         for (volatile i32 i = 0; i < 10000; ++i) {
         }
         trace::Flush();
@@ -107,9 +65,6 @@ extern "C" void KernelMain(const hal::RawBootArguments *raw_args)
         test_module.RunTestModule();
         R_ASSERT(false && "Test module should never exit!");
     }
-
-    TRACE_INFO_GENERAL("Proceeding to DebugKeyboardState...");
-    DebugKeyboardState();
 
     TRACE_INFO_GENERAL("Proceeding to KernelRun...");
     KernelRun();

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -12,13 +12,55 @@
 #include "graphics/fonts/drdos8x8.hpp"
 #include "graphics/painter.hpp"
 #include "hal/terminal.hpp"
+#include "modules/hardware.hpp"
 #include "modules/video.hpp"
 #include "sys/shell.hpp"
 
 #include "boot_args.hpp"
+#include "drivers/apic/local_apic.hpp"
 #include "hal/boot_args.hpp"
+#include "io/register.hpp"  // For port I/O
 #include "mem/heap.hpp"
+#include "modules/hardware.hpp"
 #include "todo.hpp"
+
+void DebugKeyboardState()
+{
+    using namespace hal;
+
+    // 1. Check PS/2 Status Register (Port 0x64)
+    // Bit 0 = Output Buffer Full. If 1, data is waiting.
+    u8 status = arch::IoRead<u8>(0x64);
+    DEBUG_INFO_GENERAL("PS/2 Status: 0x%02x (OBF: %d)", status, status & 1);
+
+    // 2. Check Local APIC ID and ISR
+    // We want to see if the CPU thinks it's servicing an interrupt
+    auto &lapic = HardwareModule::Get().GetInterrupts().GetLocalApic();
+    u32 id      = lapic.ReadRegister(LocalApic::kIdRegRW);
+    u32 isr     = lapic.ReadRegister(0x110);  // ISR for vectors 32-63
+    u32 irr     = lapic.ReadRegister(0x210);  // IRR for vectors 32-63
+    DEBUG_INFO_GENERAL("LAPIC ID: %u, ISR[32-63]: 0x%08x, IRR[32-63]: 0x%08x", id >> 24, isr, irr);
+
+    // 3. Check IOAPIC Redirection Entry for IRQ 1
+    // Usually IOAPIC ID 0 is the one handling ISA IRQs.
+    // GSI 1 corresponds to the keyboard.
+    // We need to access the registers manually here for debug if no getter exists.
+    auto &ioapic_table = HardwareModule::Get().GetInterrupts().GetIoApicTable();
+    if (ioapic_table.Size() > 0) {
+        auto &ioapic = ioapic_table[0];  // Assuming first IOAPIC covers GSI 0-23
+
+        // Read entry 1 (keyboard)
+        // Redirection entries start at 0x10, 2 registers per entry (low/high)
+        auto low  = ioapic.ReadRegister(0x10 + (1 * 2));
+        auto high = ioapic.ReadRegister(0x10 + (1 * 2) + 1);
+
+        DEBUG_INFO_GENERAL("IOAPIC Redir[1] Low: 0x%08x, High: 0x%08x", low, high);
+        DEBUG_INFO_GENERAL("  -> Vector: 0x%02x", low & 0xFF);
+        DEBUG_INFO_GENERAL("  -> Masked: %d", (low >> 16) & 1);
+        DEBUG_INFO_GENERAL("  -> Trigger: %s", ((low >> 15) & 1) ? "Level" : "Edge");
+        DEBUG_INFO_GENERAL("  -> Dest: %u", (high >> 24));
+    }
+}
 
 extern void KernelInit(const hal::RawBootArguments &);
 
@@ -37,20 +79,42 @@ static void KernelRun()
     }
 
     System::GraphicsConsole console(painter, font);
-    System::Shell shell(console);
+
+    System::Shell shell(console, HardwareModule::Get().GetPs2Keyboard());
 
     shell.Init();
     video.Flush();
 
+    // TRACE_INFO_GENERAL("Starting Polling Mode Debug...");
+
+    //     trace::DumpAllBuffersOnFailure();
+    // while (true) {
+    //     // Read Status Register
+    //     u8 status = arch::IoRead<u8>(0x64);
+    //
+    //     // Check Output Buffer Full (Bit 0)
+    //     if (status & 0x01) {
+    //         u8 scancode = arch::IoRead<u8>(0x60);
+    //         TRACE_INFO_GENERAL("POLLING: Got scancode 0x%02x", scancode);
+    //
+    //         // Pass to shell manually to see visual feedback
+    //         HardwareModule::Get().GetPs2Keyboard().OnInterrupt();
+    //     }
+    //
+    //     // Slow down the loop slightly to not flood logs if broken
+    //     for (volatile i32 i = 0; i < 100000; ++i) {}
+    //
+    //     video.Flush();
+    //     trace::DumpAllBuffersOnFailure();
+    // }
+
     while (true) {
-        // Poll Serial Port for input (temporary until IRQ is hooked)
-        char c = hal::TerminalGetChar();
-        shell.OnInput(c);
+        shell.Update();
         video.Flush();
 
-        // Don't burn CPU 100%
         for (volatile i32 i = 0; i < 10000; ++i) {
         }
+        trace::DumpAllBuffersOnFailure();
     }
 }
 
@@ -68,6 +132,9 @@ extern "C" void KernelMain(const hal::RawBootArguments *raw_args)
         test_module.RunTestModule();
         R_ASSERT(false && "Test module should never exit!");
     }
+
+    TRACE_INFO_GENERAL("Proceeding to DebugKeyboardState...");
+    DebugKeyboardState();
 
     TRACE_INFO_GENERAL("Proceeding to KernelRun...");
     KernelRun();

--- a/kernel/src/modules/hardware.cpp
+++ b/kernel/src/modules/hardware.cpp
@@ -11,11 +11,12 @@ internal::HardwareModule::HardwareModule() noexcept
 {
     DEBUG_INFO_GENERAL("HardwareModule::HardwareModule()");
 
-    // Initialize the generic PS/2 driver
     Ps2Keyboard_.Init();
+}
 
-    // Map Logical IRQ 1 (Standard Keyboard IRQ) to the driver
-    // Note: Interrupts::Init() must enable the hardware controller (IOAPIC/PIC)
+void internal::HardwareModule::RegisterInterruptHandlers()
+{
+    DEBUG_INFO_HARDWARE("Registering Ps2 Keyboard Handler");
     GetInterrupts().GetLit().InstallInterruptHandler<intr::InterruptType::kHardwareInterrupt>(
         1, intr::HwHandler{.handler = Ps2KeyboardHandler}
     );

--- a/kernel/src/modules/hardware.cpp
+++ b/kernel/src/modules/hardware.cpp
@@ -1,0 +1,22 @@
+#include "modules/hardware.hpp"
+
+#include "trace_framework.hpp"
+
+static void Ps2KeyboardHandler(intr::LitHwEntry &)
+{
+    HardwareModule::Get().GetPs2Keyboard().OnInterrupt();
+}
+
+internal::HardwareModule::HardwareModule() noexcept
+{
+    DEBUG_INFO_GENERAL("HardwareModule::HardwareModule()");
+
+    // Initialize the generic PS/2 driver
+    Ps2Keyboard_.Init();
+
+    // Map Logical IRQ 1 (Standard Keyboard IRQ) to the driver
+    // Note: Interrupts::Init() must enable the hardware controller (IOAPIC/PIC)
+    GetInterrupts().GetLit().InstallInterruptHandler<intr::InterruptType::kHardwareInterrupt>(
+        1, intr::HwHandler{.handler = Ps2KeyboardHandler}
+    );
+}

--- a/kernel/src/modules/hardware.hpp
+++ b/kernel/src/modules/hardware.hpp
@@ -33,6 +33,9 @@ class HardwareModule : template_lib::StaticSingletonHelper
     DEFINE_MODULE_FIELD(hardware, ClockRegistry)
     DEFINE_MODULE_FIELD(hardware, EventClockRegistry)
     DEFINE_MODULE_FIELD(Drivers::Input, Ps2Keyboard)
+
+    public:
+    void RegisterInterruptHandlers();
 };
 }  // namespace internal
 

--- a/kernel/src/modules/hardware.hpp
+++ b/kernel/src/modules/hardware.hpp
@@ -4,6 +4,7 @@
 #include <template_lib.hpp>
 
 #include "acpi/acpi.hpp"
+#include "drivers/input/ps2_keyboard.hpp"
 #include "hardware/clock_infra.hpp"
 #include "hardware/core_controller.hpp"
 #include "hardware/cores.hpp"
@@ -31,6 +32,7 @@ class HardwareModule : template_lib::StaticSingletonHelper
     DEFINE_MODULE_FIELD(hardware, CoresController)
     DEFINE_MODULE_FIELD(hardware, ClockRegistry)
     DEFINE_MODULE_FIELD(hardware, EventClockRegistry)
+    DEFINE_MODULE_FIELD(Drivers::Input, Ps2Keyboard)
 };
 }  // namespace internal
 

--- a/kernel/src/sys/shell.cpp
+++ b/kernel/src/sys/shell.cpp
@@ -29,6 +29,14 @@ void Shell::PrintPrompt()
     console_.SetColors(Graphics::Color::White(), Graphics::Color::Black());
 }
 
+void Shell::Update()
+{
+    auto result = input_reader_.GetChar();
+    if (result.has_value()) {
+        OnInput(result.value());
+    }
+}
+
 void Shell::OnInput(char c)
 {
     // Handle Special Keys

--- a/kernel/src/sys/shell.cpp
+++ b/kernel/src/sys/shell.cpp
@@ -8,7 +8,10 @@
 namespace System
 {
 
-Shell::Shell(GraphicsConsole &console) : console_(console), current_dir_(vfs::Path::kRoot) {}
+Shell::Shell(GraphicsConsole &console, IO::IReader &input_reader)
+    : console_(console), input_reader_(input_reader), current_dir_(vfs::Path::kRoot)
+{
+}
 
 void Shell::Init()
 {

--- a/kernel/src/sys/shell.hpp
+++ b/kernel/src/sys/shell.hpp
@@ -27,8 +27,11 @@ class Shell
 
     void Init();
 
-    // Call this when hardware receives a keystroke
-    void OnInput(char c);
+    /**
+     * @brief Polling function to check for new input and process it.
+     * Should be called inside the main kernel loop.
+     */
+    void Update();
 
     private:
     // -------------------------------------------------------------------------
@@ -56,6 +59,12 @@ class Shell
     // -------------------------------------------------------------------------
 
     vfs::Path ResolvePath(std::string_view path_str);
+
+    // -------------------------------------------------------------------------
+    // Internal Helpers
+    // -------------------------------------------------------------------------
+
+    void OnInput(char c);
 
     // Data
     GraphicsConsole &console_;

--- a/kernel/src/sys/shell.hpp
+++ b/kernel/src/sys/shell.hpp
@@ -4,9 +4,10 @@
 #include <data_structures/array_structures.hpp>
 #include <span.hpp>
 #include <string.hpp>
-#include <vfs/path.hpp>
 
+#include "io/stream.hpp"
 #include "sys/graphics_console.hpp"
+#include "vfs/path.hpp"
 
 namespace System
 {
@@ -18,7 +19,7 @@ namespace System
 class Shell
 {
     public:
-    explicit Shell(GraphicsConsole &console);
+    explicit Shell(GraphicsConsole &console, IO::IReader &input_reader);
 
     // -------------------------------------------------------------------------
     // Public Interface
@@ -58,6 +59,7 @@ class Shell
 
     // Data
     GraphicsConsole &console_;
+    IO::IReader &input_reader_;
     vfs::Path current_dir_;
 
     static constexpr size_t kMaxInput = 128;

--- a/kernel/src/trace.cpp
+++ b/kernel/src/trace.cpp
@@ -45,6 +45,7 @@ static struct TraceFramework {
             rv[static_cast<size_t>(TraceModule::kTime)]       = "TimeModule";
             rv[static_cast<size_t>(TraceModule::kVfs)]        = "VFSModule";
             rv[static_cast<size_t>(TraceModule::kVideo)]      = "VideoModule";
+            rv[static_cast<size_t>(TraceModule::kHardware)]   = "HardwareModule";
 
             return rv;
         }();
@@ -420,5 +421,6 @@ NODISCARD TraceLevel GetTraceLevel(TraceModule module)
     return g_TraceFramework.trace_levels[static_cast<size_t>(module)];
 }
 
-void DumpAllBuffersOnFailure() { (g_TraceFramework.*g_TraceFramework.stage_callbacks.dump_all)(); }
+void Flush() { (g_TraceFramework.*g_TraceFramework.stage_callbacks.dump_all)(); }
+void DumpAllBuffersOnFailure() { Flush(); }
 }  // namespace trace

--- a/kernel/src/trace_framework.hpp
+++ b/kernel/src/trace_framework.hpp
@@ -40,6 +40,7 @@ enum class TraceModule {
     kVfs,
     kVideo,
     kLast,
+    kHardware,
 };
 
 // ------------------------------
@@ -108,6 +109,10 @@ CREATE_TRACE_HELPERS(kTime, TIME)
 // VIDEO
 CREATE_DEBUG_HELPERS(kVideo, VIDEO)
 CREATE_TRACE_HELPERS(kVideo, VIDEO)
+
+// HARDWARE
+CREATE_DEBUG_HELPERS(kHardware, HARDWARE)
+CREATE_TRACE_HELPERS(kHardware, HARDWARE)
 
 #include "trace_framework.tpp"
 

--- a/kernel/src/trace_framework.hpp
+++ b/kernel/src/trace_framework.hpp
@@ -39,8 +39,8 @@ enum class TraceModule {
     kTime,
     kVfs,
     kVideo,
-    kLast,
     kHardware,
+    kLast,
 };
 
 // ------------------------------
@@ -50,6 +50,7 @@ enum class TraceModule {
 void AdvanceTracingStage();
 NODISCARD TraceLevel GetTraceLevel(TraceModule module);
 void DumpAllBuffersOnFailure();
+void Flush();
 
 /* MODULE TIME CORE PROC FILE LINE MSG */
 template <TraceType type, TraceModule module, TraceLevel level, class... Args>


### PR DESCRIPTION
## Problem
Handling keyboard input was done solely through legacy QemuTerminal functions with a blocking read.

## Solution
Implemented a driver for a ps2 keyboard and connected it to a interrupt handler. Shell now reads from an abstract Keyboard IReader (a pipe to which keyboard drivers write)