### PR TITLE
Add bitfield and bit array range ops

### DIFF
--- a/kernel/test/bit_array_test.cpp
+++ b/kernel/test/bit_array_test.cpp
@@ -37,6 +37,32 @@ TEST_F(BitArrayTest, CrossBoundary)
     EXPECT_FALSE(bits.Get(33));
 }
 
+TEST_F(BitArrayTest, GetSetRange_BoundariesCrossing)
+{
+    data_structures::BitArray<64> bits;
+
+    // Case 1: No boundary crossing - 5 bits at offset 2 (bits 2-6, within first byte)
+    bits.SetRange<u8, 2, 5>(0x15);  // 0b10101
+    EXPECT_EQ(0x15, (bits.GetRange<u8, 2, 5>()));
+
+    // Verify unaffected bits
+    EXPECT_EQ(0, (bits.GetRange<u8, 0, 2>()));
+    EXPECT_EQ(0, (bits.GetRange<u8, 7, 1>()));
+
+    // Case 2: One boundary crossing - 12 bits at offset 4 (bits 4-15, crosses at bit 8)
+    bits.SetRange<u16, 4, 12>(0xABC);  // 12 bits spanning 2 bytes
+    EXPECT_EQ(0xABC, (bits.GetRange<u16, 4, 12>()));
+
+    // Case 3: Multiple boundary crossings - 25 bits at offset 20 (bits 20-44, crosses 3 byte
+    // boundaries) Crosses at bits 24, 32, 40
+    bits.SetRange<u32, 20, 25>(0x1FEDCBA);
+    EXPECT_EQ(0x1FEDCBA, (bits.GetRange<u32, 20, 25>()));
+
+    // Verify unaffected bits
+    EXPECT_EQ(0, (bits.GetRange<u8, 16, 4>()));
+    EXPECT_EQ(0, (bits.GetRange<u8, 45, 3>()));
+}
+
 TEST_F(BitArrayTest, Size)
 {
     data_structures::BitArray<100> bits;

--- a/kernel/test/bit_array_test.cpp
+++ b/kernel/test/bit_array_test.cpp
@@ -39,28 +39,25 @@ TEST_F(BitArrayTest, CrossBoundary)
 
 TEST_F(BitArrayTest, GetSetRange_BoundariesCrossing)
 {
-    data_structures::BitArray<64> bits;
+    data_structures::BitArray<192> bits;
 
-    // Case 1: No boundary crossing - 5 bits at offset 2 (bits 2-6, within first byte)
-    bits.SetRange<u8, 2, 5>(0x15);  // 0b10101
-    EXPECT_EQ(0x15, (bits.GetRange<u8, 2, 5>()));
-
-    // Verify unaffected bits
-    EXPECT_EQ(0, (bits.GetRange<u8, 0, 2>()));
-    EXPECT_EQ(0, (bits.GetRange<u8, 7, 1>()));
-
-    // Case 2: One boundary crossing - 12 bits at offset 4 (bits 4-15, crosses at bit 8)
-    bits.SetRange<u16, 4, 12>(0xABC);  // 12 bits spanning 2 bytes
-    EXPECT_EQ(0xABC, (bits.GetRange<u16, 4, 12>()));
-
-    // Case 3: Multiple boundary crossings - 25 bits at offset 20 (bits 20-44, crosses 3 byte
-    // boundaries) Crosses at bits 24, 32, 40
-    bits.SetRange<u32, 20, 25>(0x1FEDCBA);
-    EXPECT_EQ(0x1FEDCBA, (bits.GetRange<u32, 20, 25>()));
+    // No boundary crossing - 48 bits at offset 2
+    bits.SetRange<2, 48>(0x15);
+    EXPECT_EQ(0x15, (bits.GetRange<2, 48>()));
 
     // Verify unaffected bits
-    EXPECT_EQ(0, (bits.GetRange<u8, 16, 4>()));
-    EXPECT_EQ(0, (bits.GetRange<u8, 45, 3>()));
+    EXPECT_EQ(0, (bits.GetRange<0, 2>()));
+    EXPECT_EQ(0, (bits.GetRange<50, 64>()));
+
+    bits.SetAll(false);
+
+    // Boundary crossing - 32 bits at offset 48
+    bits.SetRange<48, 32>(0xABC);
+    EXPECT_EQ(0xABC, (bits.GetRange<48, 32>()));
+
+    // Verify unaffected bits
+    EXPECT_EQ(0, (bits.GetRange<0, 48>()));
+    EXPECT_EQ(0, (bits.GetRange<80, 64>()));
 }
 
 TEST_F(BitArrayTest, Size)

--- a/kernel/test/bitfield_test.cpp
+++ b/kernel/test/bitfield_test.cpp
@@ -1,0 +1,77 @@
+#include <data_structures/bitfield.hpp>
+#include <test_module/test.hpp>
+#include <types.hpp>
+
+class BitFieldTest : public TestGroupBase
+{
+};
+
+CREATE_BITFIELD(TestBitField1, FieldA, 3, FieldB, 5, FieldC, 8);
+
+CREATE_BITFIELD(TestBitField2, FlagX, 1, FlagY, 1, Counter, 6);
+
+CREATE_BITFIELD(StatusReg, Ready, 1, Error, 1, ErrorCode, 6, Reserved, 24);
+
+static_assert(sizeof(StatusReg) == sizeof(u32));
+static_assert(StatusReg::kTotalBits == 32);
+static_assert(sizeof(TestBitField1) == sizeof(u16));
+static_assert(sizeof(TestBitField2) == sizeof(u8));
+
+struct RawStatus {
+    u32 flags;
+};
+
+TEST_F(BitFieldTest, BitFieldConstruction)
+{
+    TestBitField1 bf1{static_cast<u16>(0x1FF8)};
+    EXPECT_EQ(0, bf1.get<TestBitField1::FieldA>());
+    EXPECT_EQ(31, bf1.get<TestBitField1::FieldB>());
+    EXPECT_EQ(31, bf1.get<TestBitField1::FieldC>());
+
+    TestBitField2 bf2;
+    EXPECT_EQ(0, bf2.get<TestBitField2::FlagX>());
+    EXPECT_EQ(0, bf2.get<TestBitField2::FlagY>());
+    EXPECT_EQ(0, bf2.get<TestBitField2::Counter>());
+}
+
+TEST_F(BitFieldTest, BitFieldIntegerConstruction)
+{
+    u32 val1 = 0x01000003;  // Binary ...00011 (Ready=1, Error=1)
+    StatusReg reg(val1);
+
+    EXPECT_EQ(1, reg.get<StatusReg::Ready>());
+    EXPECT_EQ(1, reg.get<StatusReg::Error>());
+
+    RawStatus raw{0xFFFFFFFF};
+    reg = raw;
+
+    EXPECT_EQ(63, reg.get<StatusReg::ErrorCode>());
+    EXPECT_EQ(16777215, reg.get<StatusReg::Reserved>());
+
+    reg.set<StatusReg::Ready>(0);
+    reg.set<StatusReg::Error>(0);
+
+    u32 val = static_cast<u32>(reg);
+    EXPECT_EQ(0xFFFFFFFC, val);
+}
+
+TEST_F(BitFieldTest, BitFieldSetGet)
+{
+    TestBitField1 bf1;
+    bf1.set<TestBitField1::FieldA>(5);
+    bf1.set<TestBitField1::FieldB>(17);
+    bf1.set<TestBitField1::FieldC>(255);
+
+    EXPECT_EQ(5, bf1.get<TestBitField1::FieldA>());
+    EXPECT_EQ(17, bf1.get<TestBitField1::FieldB>());
+    EXPECT_EQ(255, bf1.get<TestBitField1::FieldC>());
+
+    TestBitField2 bf2;
+    bf2.set<TestBitField2::FlagX>(1);
+    bf2.set<TestBitField2::FlagY>(0);
+    bf2.set<TestBitField2::Counter>(42);
+
+    EXPECT_EQ(1, bf2.get<TestBitField2::FlagX>());
+    EXPECT_EQ(0, bf2.get<TestBitField2::FlagY>());
+    EXPECT_EQ(42, bf2.get<TestBitField2::Counter>());
+}

--- a/libs/libcontainers/include/data_structures/bit_array.hpp
+++ b/libs/libcontainers/include/data_structures/bit_array.hpp
@@ -82,9 +82,8 @@ class BitMapView final
 template <size_t kNumBits>
 class PACK BitArray final
 {
-    using StorageT                        = u8;
-    static constexpr size_t kStorageTBits = sizeof(StorageT) * 8;
-    static constexpr size_t kNumStorageT  = (kNumBits + kStorageTBits - 1) / kStorageTBits;
+    using StorageT                       = u8;
+    static constexpr size_t kStorageBits = sizeof(StorageT) * 8;
 
     public:
     // ------------------------------
@@ -102,14 +101,14 @@ class PACK BitArray final
     {
         ASSERT_LT(index, kNumBits, "Index out of bounds in BitArray");
 
-        storage_[index / kStorageTBits] |= (kLsb<StorageT> << (index % kStorageTBits));
+        storage_[index / kStorageBits] |= (kLsb<StorageT> << (index % kStorageBits));
     }
 
     FORCE_INLINE_F void SetFalse(const size_t index)
     {
         ASSERT_LT(index, kNumBits, "Index out of bounds in BitArray");
 
-        storage_[index / kStorageTBits] &= ~(kLsb<StorageT> << (index % kStorageTBits));
+        storage_[index / kStorageBits] &= ~(kLsb<StorageT> << (index % kStorageBits));
     }
 
     FORCE_INLINE_F void Set(const size_t index, const bool value)
@@ -117,20 +116,103 @@ class PACK BitArray final
         ASSERT_LT(index, kNumBits, "Index out of bounds in BitArray");
 
         SetFalse(index);
-        storage_[index / kStorageTBits] |= (static_cast<u32>(value) << (index % kStorageTBits));
+        storage_[index / kStorageBits] |= (static_cast<u32>(value) << (index % kStorageBits));
     }
 
     NODISCARD FORCE_INLINE_F bool Get(const size_t index) const
     {
         ASSERT_LT(index, kNumBits, "Index out of bounds in BitArray");
-        return (storage_[index / kStorageTBits] >> (index % kStorageTBits)) & kLsb<StorageT>;
+        return (storage_[index / kStorageBits] >> (index % kStorageBits)) & kLsb<StorageT>;
+    }
+
+    template <typename T, size_t Offset, size_t Width>
+    NODISCARD FORCE_INLINE_F T GetRange() const
+    {
+        static_assert(Offset + Width <= kNumBits, "Range exceeds BitArray size");
+
+        constexpr size_t byte_offset = Offset / 8;
+        constexpr size_t bit_offset  = Offset % 8;
+
+        if constexpr (bit_offset + Width <= 64) {
+            u64 raw = *reinterpret_cast<const u64 *>(storage_ + byte_offset);
+
+            // Shift right to align, then mask
+            constexpr u64 mask = kBitMaskRight<u64, Width>;
+            return static_cast<T>((raw >> bit_offset) & mask);
+        } else {
+            // Spans two 64-bit words
+            constexpr size_t first_width  = 64 - bit_offset;
+            constexpr size_t second_width = Width - first_width;
+
+            // Read first word
+            u64 raw1            = *reinterpret_cast<const u64 *>(storage_ + byte_offset);
+            constexpr u64 mask1 = kBitMaskRight<u64, first_width>;
+            T result            = static_cast<T>((raw1 >> bit_offset) & mask1);
+
+            // Read second word
+            u64 raw2            = *reinterpret_cast<const u64 *>(storage_ + byte_offset + 8);
+            constexpr u64 mask2 = kBitMaskRight<u64, second_width>;
+            result |= static_cast<T>((raw2 & mask2) << first_width);
+
+            return result;
+        }
+    }
+
+    template <typename T, size_t Offset, size_t Width>
+    FORCE_INLINE_F void SetRange(T value)
+    {
+        static_assert(Offset + Width <= kNumBits, "Range exceeds BitArray size");
+
+        // Mask value to width
+        constexpr T value_mask = kBitMaskRight<T, Width>;
+        value &= value_mask;
+
+        constexpr size_t byte_offset = Offset / 8;
+        constexpr size_t bit_offset  = Offset % 8;
+
+        if constexpr (bit_offset + Width <= 64) {
+            auto *raw_ptr = reinterpret_cast<u64 *>(storage_ + byte_offset);
+            u64 raw       = *raw_ptr;
+
+            // Create clear mask at the correct position
+            constexpr u64 clear_mask = kBitMaskRight<u64, Width> << bit_offset;
+
+            // Clear bits: use ~mask & raw
+            raw &= ~clear_mask;
+
+            // Set new bits: shift value and OR
+            raw |= (static_cast<u64>(value) << bit_offset);
+
+            // Write back
+            *raw_ptr = raw;
+        } else {
+            // Spans two 64-bit words - split the operation
+            constexpr size_t first_width  = 64 - bit_offset;
+            constexpr size_t second_width = Width - first_width;
+
+            // First word: clear and set lower bits
+            auto *raw_ptr1            = reinterpret_cast<u64 *>(storage_ + byte_offset);
+            u64 raw1                  = *raw_ptr1;
+            constexpr u64 clear_mask1 = kBitMaskRight<u64, first_width> << bit_offset;
+            raw1 &= ~clear_mask1;
+            raw1 |= (static_cast<u64>(value) << bit_offset);
+            *raw_ptr1 = raw1;
+
+            // Second word: clear and set upper bits
+            auto *raw_ptr2            = reinterpret_cast<u64 *>(storage_ + byte_offset + 8);
+            u64 raw2                  = *raw_ptr2;
+            constexpr u64 clear_mask2 = kBitMaskRight<u64, second_width>;
+            raw2 &= ~clear_mask2;
+            raw2 |= (static_cast<u64>(value) >> first_width);
+            *raw_ptr2 = raw2;
+        }
     }
 
     NODISCARD FORCE_INLINE_F size_t Size() const { return kNumBits; }
 
     FORCE_INLINE_F void SetAll(const bool value)
     {
-        memset(storage_, value ? UINT8_MAX : 0, kNumStorageT * sizeof(StorageT));
+        memset(storage_, value ? UINT8_MAX : 0, kNumStorage * sizeof(StorageT));
     }
 
     FORCE_INLINE_F u64 ToU64() const
@@ -178,8 +260,10 @@ class PACK BitArray final
     // Class fields
     // ------------------------------
 
+    static constexpr size_t kNumStorage = (kNumBits + kStorageBits - 1) / kStorageBits;
+
     private:
-    StorageT storage_[kNumStorageT]{};
+    StorageT storage_[kNumStorage]{};
 };
 
 }  // namespace data_structures

--- a/libs/libcontainers/include/data_structures/bit_array.hpp
+++ b/libs/libcontainers/include/data_structures/bit_array.hpp
@@ -125,90 +125,90 @@ class PACK BitArray final
         return (storage_[index / kStorageBits] >> (index % kStorageBits)) & kLsb<StorageT>;
     }
 
-    template <size_t Offset, size_t Width>
+    template <size_t kOffset, size_t kWidth>
     NODISCARD FORCE_INLINE_F size_t GetRange() const
     {
         constexpr size_t kSizeTBits = sizeof(size_t) * 8;
-        static_assert(Offset + Width <= kNumBits, "Range exceeds BitArray size");
-        static_assert(Width <= kSizeTBits, "Width exceeds size_t size");
+        static_assert(kOffset + kWidth <= kNumBits, "Range exceeds BitArray size");
+        static_assert(kWidth <= kSizeTBits, "Width exceeds size_t size");
 
-        constexpr size_t byte_offset = Offset / 8;
-        constexpr size_t bit_offset  = Offset % 8;
+        constexpr size_t kByteOffset = kOffset / 8;
+        constexpr size_t kBitOffset  = kOffset % 8;
 
-        if constexpr (bit_offset + Width <= kSizeTBits) {
-            size_t raw = *reinterpret_cast<const size_t *>(storage_ + byte_offset);
+        if constexpr (kBitOffset + kWidth <= kSizeTBits) {
+            size_t raw = *reinterpret_cast<const size_t *>(storage_ + kByteOffset);
 
             // Shift right to align, then mask
-            constexpr size_t mask = kBitMaskRight<size_t, Width>;
-            return (raw >> bit_offset) & mask;
+            constexpr size_t kMask = kBitMaskRight<size_t, kWidth>;
+            return (raw >> kBitOffset) & kMask;
         } else {
             // Spans two register-sized words
-            constexpr size_t first_width  = kSizeTBits - bit_offset;
-            constexpr size_t second_width = Width - first_width;
+            constexpr size_t kFirstWidth  = kSizeTBits - kBitOffset;
+            constexpr size_t kSecondWidth = kWidth - kFirstWidth;
 
             // Read first word
-            size_t raw1            = *reinterpret_cast<const size_t *>(storage_ + byte_offset);
-            constexpr size_t mask1 = kBitMaskRight<size_t, first_width>;
-            size_t result          = (raw1 >> bit_offset) & mask1;
+            size_t raw1             = *reinterpret_cast<const size_t *>(storage_ + kByteOffset);
+            constexpr size_t kMask1 = kBitMaskRight<size_t, kFirstWidth>;
+            size_t result           = (raw1 >> kBitOffset) & kMask1;
 
             // Read second word
             size_t raw2 =
-                *reinterpret_cast<const size_t *>(storage_ + byte_offset + sizeof(size_t));
-            constexpr size_t mask2 = kBitMaskRight<size_t, second_width>;
-            result |= (raw2 & mask2) << first_width;
+                *reinterpret_cast<const size_t *>(storage_ + kByteOffset + sizeof(size_t));
+            constexpr size_t kMask2 = kBitMaskRight<size_t, kSecondWidth>;
+            result |= (raw2 & kMask2) << kFirstWidth;
 
             return result;
         }
     }
 
-    template <size_t Offset, size_t Width>
+    template <size_t kOffset, size_t kWidth>
     FORCE_INLINE_F void SetRange(size_t value)
     {
         constexpr size_t kSizeTBits = sizeof(size_t) * 8;
-        static_assert(Offset + Width <= kNumBits, "Range exceeds BitArray size");
-        static_assert(Width <= kSizeTBits, "Width exceeds size_t size");
+        static_assert(kOffset + kWidth <= kNumBits, "Range exceeds BitArray size");
+        static_assert(kWidth <= kSizeTBits, "Width exceeds size_t size");
 
         // Mask value to width
-        constexpr size_t value_mask = kBitMaskRight<size_t, Width>;
-        value &= value_mask;
+        constexpr size_t kValueMask = kBitMaskRight<size_t, kWidth>;
+        value &= kValueMask;
 
-        constexpr size_t byte_offset = Offset / 8;
-        constexpr size_t bit_offset  = Offset % 8;
+        constexpr size_t kByteOffset = kOffset / 8;
+        constexpr size_t kBitOffset  = kOffset % 8;
 
-        if constexpr (bit_offset + Width <= kSizeTBits) {
-            auto *raw_ptr = reinterpret_cast<size_t *>(storage_ + byte_offset);
+        if constexpr (kBitOffset + kWidth <= kSizeTBits) {
+            auto *raw_ptr = reinterpret_cast<size_t *>(storage_ + kByteOffset);
             size_t raw    = *raw_ptr;
 
             // Create clear mask at the correct position
-            constexpr size_t clear_mask = kBitMaskRight<size_t, Width> << bit_offset;
+            constexpr size_t kClearMask = kBitMaskRight<size_t, kWidth> << kBitOffset;
 
             // Clear bits: use ~mask & raw
-            raw &= ~clear_mask;
+            raw &= ~kClearMask;
 
             // Set new bits: shift value and OR
-            raw |= (value << bit_offset);
+            raw |= (value << kBitOffset);
 
             // Write back
             *raw_ptr = raw;
         } else {
             // Spans two register-sized words - split the operation
-            constexpr size_t first_width  = kSizeTBits - bit_offset;
-            constexpr size_t second_width = Width - first_width;
+            constexpr size_t kFirstWidth  = kSizeTBits - kBitOffset;
+            constexpr size_t kSecondWidth = kWidth - kFirstWidth;
 
             // First word: clear and set lower bits
-            auto *raw_ptr1               = reinterpret_cast<size_t *>(storage_ + byte_offset);
+            auto *raw_ptr1               = reinterpret_cast<size_t *>(storage_ + kByteOffset);
             size_t raw1                  = *raw_ptr1;
-            constexpr size_t clear_mask1 = kBitMaskRight<size_t, first_width> << bit_offset;
-            raw1 &= ~clear_mask1;
-            raw1 |= (value << bit_offset);
+            constexpr size_t kClearMask1 = kBitMaskRight<size_t, kFirstWidth> << kBitOffset;
+            raw1 &= ~kClearMask1;
+            raw1 |= (value << kBitOffset);
             *raw_ptr1 = raw1;
 
             // Second word: clear and set upper bits
-            auto *raw_ptr2 = reinterpret_cast<size_t *>(storage_ + byte_offset + sizeof(size_t));
+            auto *raw_ptr2 = reinterpret_cast<size_t *>(storage_ + kByteOffset + sizeof(size_t));
             size_t raw2    = *raw_ptr2;
-            constexpr size_t clear_mask2 = kBitMaskRight<size_t, second_width>;
-            raw2 &= ~clear_mask2;
-            raw2 |= (value >> first_width);
+            constexpr size_t kClearMask2 = kBitMaskRight<size_t, kSecondWidth>;
+            raw2 &= ~kClearMask2;
+            raw2 |= (value >> kFirstWidth);
             *raw_ptr2 = raw2;
         }
     }

--- a/libs/libcontainers/include/data_structures/bit_array.hpp
+++ b/libs/libcontainers/include/data_structures/bit_array.hpp
@@ -125,85 +125,90 @@ class PACK BitArray final
         return (storage_[index / kStorageBits] >> (index % kStorageBits)) & kLsb<StorageT>;
     }
 
-    template <typename T, size_t Offset, size_t Width>
-    NODISCARD FORCE_INLINE_F T GetRange() const
+    template <size_t Offset, size_t Width>
+    NODISCARD FORCE_INLINE_F size_t GetRange() const
     {
+        constexpr size_t kSizeTBits = sizeof(size_t) * 8;
         static_assert(Offset + Width <= kNumBits, "Range exceeds BitArray size");
+        static_assert(Width <= kSizeTBits, "Width exceeds size_t size");
 
         constexpr size_t byte_offset = Offset / 8;
         constexpr size_t bit_offset  = Offset % 8;
 
-        if constexpr (bit_offset + Width <= 64) {
-            u64 raw = *reinterpret_cast<const u64 *>(storage_ + byte_offset);
+        if constexpr (bit_offset + Width <= kSizeTBits) {
+            size_t raw = *reinterpret_cast<const size_t *>(storage_ + byte_offset);
 
             // Shift right to align, then mask
-            constexpr u64 mask = kBitMaskRight<u64, Width>;
-            return static_cast<T>((raw >> bit_offset) & mask);
+            constexpr size_t mask = kBitMaskRight<size_t, Width>;
+            return (raw >> bit_offset) & mask;
         } else {
-            // Spans two 64-bit words
-            constexpr size_t first_width  = 64 - bit_offset;
+            // Spans two register-sized words
+            constexpr size_t first_width  = kSizeTBits - bit_offset;
             constexpr size_t second_width = Width - first_width;
 
             // Read first word
-            u64 raw1            = *reinterpret_cast<const u64 *>(storage_ + byte_offset);
-            constexpr u64 mask1 = kBitMaskRight<u64, first_width>;
-            T result            = static_cast<T>((raw1 >> bit_offset) & mask1);
+            size_t raw1            = *reinterpret_cast<const size_t *>(storage_ + byte_offset);
+            constexpr size_t mask1 = kBitMaskRight<size_t, first_width>;
+            size_t result          = (raw1 >> bit_offset) & mask1;
 
             // Read second word
-            u64 raw2            = *reinterpret_cast<const u64 *>(storage_ + byte_offset + 8);
-            constexpr u64 mask2 = kBitMaskRight<u64, second_width>;
-            result |= static_cast<T>((raw2 & mask2) << first_width);
+            size_t raw2 =
+                *reinterpret_cast<const size_t *>(storage_ + byte_offset + sizeof(size_t));
+            constexpr size_t mask2 = kBitMaskRight<size_t, second_width>;
+            result |= (raw2 & mask2) << first_width;
 
             return result;
         }
     }
 
-    template <typename T, size_t Offset, size_t Width>
-    FORCE_INLINE_F void SetRange(T value)
+    template <size_t Offset, size_t Width>
+    FORCE_INLINE_F void SetRange(size_t value)
     {
+        constexpr size_t kSizeTBits = sizeof(size_t) * 8;
         static_assert(Offset + Width <= kNumBits, "Range exceeds BitArray size");
+        static_assert(Width <= kSizeTBits, "Width exceeds size_t size");
 
         // Mask value to width
-        constexpr T value_mask = kBitMaskRight<T, Width>;
+        constexpr size_t value_mask = kBitMaskRight<size_t, Width>;
         value &= value_mask;
 
         constexpr size_t byte_offset = Offset / 8;
         constexpr size_t bit_offset  = Offset % 8;
 
-        if constexpr (bit_offset + Width <= 64) {
-            auto *raw_ptr = reinterpret_cast<u64 *>(storage_ + byte_offset);
-            u64 raw       = *raw_ptr;
+        if constexpr (bit_offset + Width <= kSizeTBits) {
+            auto *raw_ptr = reinterpret_cast<size_t *>(storage_ + byte_offset);
+            size_t raw    = *raw_ptr;
 
             // Create clear mask at the correct position
-            constexpr u64 clear_mask = kBitMaskRight<u64, Width> << bit_offset;
+            constexpr size_t clear_mask = kBitMaskRight<size_t, Width> << bit_offset;
 
             // Clear bits: use ~mask & raw
             raw &= ~clear_mask;
 
             // Set new bits: shift value and OR
-            raw |= (static_cast<u64>(value) << bit_offset);
+            raw |= (value << bit_offset);
 
             // Write back
             *raw_ptr = raw;
         } else {
-            // Spans two 64-bit words - split the operation
-            constexpr size_t first_width  = 64 - bit_offset;
+            // Spans two register-sized words - split the operation
+            constexpr size_t first_width  = kSizeTBits - bit_offset;
             constexpr size_t second_width = Width - first_width;
 
             // First word: clear and set lower bits
-            auto *raw_ptr1            = reinterpret_cast<u64 *>(storage_ + byte_offset);
-            u64 raw1                  = *raw_ptr1;
-            constexpr u64 clear_mask1 = kBitMaskRight<u64, first_width> << bit_offset;
+            auto *raw_ptr1               = reinterpret_cast<size_t *>(storage_ + byte_offset);
+            size_t raw1                  = *raw_ptr1;
+            constexpr size_t clear_mask1 = kBitMaskRight<size_t, first_width> << bit_offset;
             raw1 &= ~clear_mask1;
-            raw1 |= (static_cast<u64>(value) << bit_offset);
+            raw1 |= (value << bit_offset);
             *raw_ptr1 = raw1;
 
             // Second word: clear and set upper bits
-            auto *raw_ptr2            = reinterpret_cast<u64 *>(storage_ + byte_offset + 8);
-            u64 raw2                  = *raw_ptr2;
-            constexpr u64 clear_mask2 = kBitMaskRight<u64, second_width>;
+            auto *raw_ptr2 = reinterpret_cast<size_t *>(storage_ + byte_offset + sizeof(size_t));
+            size_t raw2    = *raw_ptr2;
+            constexpr size_t clear_mask2 = kBitMaskRight<size_t, second_width>;
             raw2 &= ~clear_mask2;
-            raw2 |= (static_cast<u64>(value) >> first_width);
+            raw2 |= (value >> first_width);
             *raw_ptr2 = raw2;
         }
     }

--- a/libs/libcontainers/include/data_structures/bit_array.hpp
+++ b/libs/libcontainers/include/data_structures/bit_array.hpp
@@ -234,12 +234,12 @@ class PACK BitArray final
         const StorageT empty_unit =
             value ? std::numeric_limits<StorageT>::min() : std::numeric_limits<StorageT>::max();
 
-        for (size_t i = 0; i < kNumStorageT; ++i) {
+        for (size_t i = 0; i < kNumStorage; ++i) {
             if (storage_[i] == empty_unit) {
                 continue;
             }
 
-            const size_t start = i * kStorageTBits;
+            const size_t start = i * kStorageBits;
             const size_t local_offset =
                 value ? std::countr_zero(storage_[i]) : std::countr_one(storage_[i]);
             return start + local_offset;

--- a/libs/libcontainers/include/data_structures/bitfield.hpp
+++ b/libs/libcontainers/include/data_structures/bitfield.hpp
@@ -12,34 +12,34 @@ namespace data_structures::internal
 {
 
 // Type-safe field tag
-template <typename Owner, std::size_t Index, std::size_t Width>
+template <typename Owner, size_t Index, size_t Width>
 struct BitFieldTag {
-    using owner_type                   = Owner;
-    static constexpr std::size_t index = Index;
-    static constexpr std::size_t width = Width;
+    using owner_type              = Owner;
+    static constexpr size_t index = Index;
+    static constexpr size_t width = Width;
 };
 
 // BitField specification
 template <typename Tag>
 struct BitFieldSpec {
-    using tag_type                     = Tag;
-    static constexpr std::size_t width = Tag::width;
-    static constexpr std::size_t index = Tag::index;
+    using tag_type                = Tag;
+    static constexpr size_t width = Tag::width;
+    static constexpr size_t index = Tag::index;
 };
 
 // Calculate offset for a field at Index
-template <std::size_t Index, typename... Specs>
+template <size_t Index, typename... Specs>
 struct OffsetCalculator;
 
-template <std::size_t Index, typename First, typename... Rest>
+template <size_t Index, typename First, typename... Rest>
 struct OffsetCalculator<Index, First, Rest...> {
-    static constexpr std::size_t value =
+    static constexpr size_t value =
         (Index == First::index) ? 0 : First::width + OffsetCalculator<Index, Rest...>::value;
 };
 
-template <std::size_t Index, typename First>
+template <size_t Index, typename First>
 struct OffsetCalculator<Index, First> {
-    static constexpr std::size_t value = (Index == First::index) ? 0 : First::width;
+    static constexpr size_t value = (Index == First::index) ? 0 : First::width;
 };
 
 // Calculate total size in bits
@@ -48,25 +48,25 @@ struct TotalSize;
 
 template <typename First, typename... Rest>
 struct TotalSize<First, Rest...> {
-    static constexpr std::size_t value = First::width + TotalSize<Rest...>::value;
+    static constexpr size_t value = First::width + TotalSize<Rest...>::value;
 };
 
 template <>
 struct TotalSize<> {
-    static constexpr std::size_t value = 0;
+    static constexpr size_t value = 0;
 };
 
 // Find spec by tag index
-template <std::size_t Index, typename... Specs>
+template <size_t Index, typename... Specs>
 struct FindSpecByIndex;
 
-template <std::size_t Index, typename First, typename... Rest>
+template <size_t Index, typename First, typename... Rest>
 struct FindSpecByIndex<Index, First, Rest...> {
     static constexpr bool found = (First::index == Index);
     using type = std::conditional_t<found, First, typename FindSpecByIndex<Index, Rest...>::type>;
 };
 
-template <std::size_t Index>
+template <size_t Index>
 struct FindSpecByIndex<Index> {
     static constexpr bool found = false;
     using type                  = void;
@@ -90,26 +90,7 @@ template <typename Derived, typename... FieldSpecs>
 class EnumBitFieldsBase
 {
     public:
-    static constexpr std::size_t kTotalBits = TotalSize<FieldSpecs...>::value;
-
-    protected:
-    BitArray<kTotalBits> data_;
-
-    template <typename T, std::size_t Offset, std::size_t Width>
-    static constexpr T extract_bits(const BitArray<kTotalBits> &arr)
-    {
-        return arr.template GetRange<T, Offset, Width>();
-    }
-
-    template <typename T, std::size_t Offset, std::size_t Width>
-    static constexpr void insert_bits(BitArray<kTotalBits> &arr, T value)
-    {
-        arr.template SetRange<T, Offset, Width>(value);
-    }
-
-    public:
-    constexpr EnumBitFieldsBase() = default;
-
+    constexpr EnumBitFieldsBase()                          = default;
     constexpr EnumBitFieldsBase(const EnumBitFieldsBase &) = default;
 
     template <typename OtherDerived, typename... OtherSpecs>
@@ -118,8 +99,7 @@ class EnumBitFieldsBase
     {
         static_assert(
             kTotalBits == EnumBitFieldsBase<OtherDerived, OtherSpecs...>::kTotalBits,
-            "BitField construction failed: Source and Destination must have the same total size in "
-            "bits."
+            "Source and Destination must have the same total size in bits."
         );
     }
 
@@ -127,8 +107,7 @@ class EnumBitFieldsBase
     constexpr explicit EnumBitFieldsBase(const T &value)
     {
         static_assert(
-            sizeof(T) == data_.kNumStorage,
-            "Raw Type construction failed: Size of input type must match BitField storage size."
+            sizeof(T) == data_.kNumStorage, "Size of input type must match BitField storage size."
         );
 
         data_ = std::bit_cast<BitArray<kTotalBits>>(value);
@@ -138,8 +117,7 @@ class EnumBitFieldsBase
     constexpr EnumBitFieldsBase &operator=(const T &value)
     {
         static_assert(
-            sizeof(T) == data_.kNumStorage,
-            "Raw Type assignment failed: Size of input type must match BitField storage size."
+            sizeof(T) == data_.kNumStorage, "Size of input type must match BitField storage size."
         );
 
         data_ = std::bit_cast<BitArray<kTotalBits>>(value);
@@ -151,7 +129,7 @@ class EnumBitFieldsBase
     {
         static_assert(
             sizeof(T) == data_.kNumStorage,
-            "Cast to Raw Type failed: Size of destination type must match BitField storage size."
+            "Size of destination type must match BitField storage size."
         );
 
         return std::bit_cast<T>(data_);
@@ -164,42 +142,37 @@ class EnumBitFieldsBase
     {
         static_assert(
             kTotalBits == EnumBitFieldsBase<OtherDerived, OtherSpecs...>::kTotalBits,
-            "BitField assignment failed: Source and Destination bitfields must have the same total "
-            "size in bits."
+            "Source and Destination bitfields must have the same total size in bits."
         );
 
-        this->data_ = other.storage();
+        this->data_ = other.data_;
         return *this;
     }
 
-    template <std::size_t Index>
-    static constexpr std::size_t offset_for()
+    template <typename Tag>
+    constexpr size_t get() const
     {
-        return OffsetCalculator<Index, FieldSpecs...>::value;
+        static_assert(std::is_same_v<typename Tag::owner_type, Derived>, "Invalid Tag used");
+        using Spec = typename FindSpecByIndex<Tag::index, FieldSpecs...>::type;
+        return data_.template GetRange<OffsetFor<Tag::index>, Spec::width>();
     }
 
     template <typename Tag>
-    constexpr auto get() const
+    constexpr void set(size_t value)
     {
         static_assert(std::is_same_v<typename Tag::owner_type, Derived>, "Invalid Tag used");
-        using Spec                   = typename FindSpecByIndex<Tag::index, FieldSpecs...>::type;
-        constexpr std::size_t offset = offset_for<Tag::index>();
-        constexpr std::size_t width  = Spec::width;
-        return extract_bits<std::size_t, offset, width>(data_);
+        using Spec = typename FindSpecByIndex<Tag::index, FieldSpecs...>::type;
+        data_.template SetRange<OffsetFor<Tag::index>, Spec::width>(value);
     }
 
-    template <typename Tag>
-    constexpr void set(std::size_t value)
-    {
-        static_assert(std::is_same_v<typename Tag::owner_type, Derived>, "Invalid Tag used");
-        using Spec                   = typename FindSpecByIndex<Tag::index, FieldSpecs...>::type;
-        constexpr std::size_t offset = offset_for<Tag::index>();
-        constexpr std::size_t width  = Spec::width;
-        insert_bits<std::size_t, offset, width>(data_, value);
-    }
+    static constexpr size_t kTotalBits = TotalSize<FieldSpecs...>::value;
 
-    constexpr const BitArray<kTotalBits> &storage() const { return data_; }
-    constexpr BitArray<kTotalBits> &storage() { return data_; }
+    private:
+    template <size_t Index>
+    static constexpr size_t OffsetFor = OffsetCalculator<Index, FieldSpecs...>::value;
+
+    protected:
+    BitArray<kTotalBits> data_;
 };
 
 }  // namespace data_structures::internal
@@ -208,36 +181,36 @@ class EnumBitFieldsBase
 
 #define BF_FIELD_TAG(ctx, name, width)                   \
     using name = data_structures::internal::BitFieldTag< \
-        ctx::Owner, static_cast<std::size_t>(ctx::Index::k##name), width>
+        ctx::Owner, static_cast<size_t>(ctx::Index::k##name), width>
 
 #define BF_FIELD_SPEC(ctx, name, width)                                             \
     data_structures::internal::BitFieldSpec<data_structures::internal::BitFieldTag< \
-        ctx::Owner, static_cast<std::size_t>(ctx::Index::k##name), width>>
+        ctx::Owner, static_cast<size_t>(ctx::Index::k##name), width>>
 
-#define CREATE_BITFIELD(ClassName, ...)                                                      \
-    class ClassName;                                                                         \
-                                                                                             \
-    namespace ClassName##Details                                                             \
-    {                                                                                        \
-        using Owner = ClassName;                                                             \
-        enum class Index : std::size_t { FOR_EACH_PAIR(BF_ENUM_ENTRY, __VA_ARGS__), kLast }; \
-    }                                                                                        \
-                                                                                             \
-    class ClassName                                                                          \
-        : public data_structures::internal::EnumBitFieldsBase<                               \
-              ClassName, FOR_EACH_PAIR_CTX(BF_FIELD_SPEC, ClassName##Details, __VA_ARGS__)>  \
-    {                                                                                        \
-        private:                                                                             \
-        using Base = data_structures::internal::EnumBitFieldsBase<                           \
-            ClassName, FOR_EACH_PAIR_CTX(BF_FIELD_SPEC, ClassName##Details, __VA_ARGS__)>;   \
-                                                                                             \
-        public:                                                                              \
-        using Base::Base;                                                                    \
-        using Base::operator=;                                                               \
-        using Base::get;                                                                     \
-        using Base::set;                                                                     \
-                                                                                             \
-        FOR_EACH_PAIR_CTX_SEP(SEMICOLON, BF_FIELD_TAG, ClassName##Details, __VA_ARGS__);     \
+#define CREATE_BITFIELD(ClassName, ...)                                                     \
+    class ClassName;                                                                        \
+                                                                                            \
+    namespace ClassName##Details                                                            \
+    {                                                                                       \
+        using Owner = ClassName;                                                            \
+        enum class Index : size_t { FOR_EACH_PAIR(BF_ENUM_ENTRY, __VA_ARGS__), kLast };     \
+    }                                                                                       \
+                                                                                            \
+    class ClassName                                                                         \
+        : public data_structures::internal::EnumBitFieldsBase<                              \
+              ClassName, FOR_EACH_PAIR_CTX(BF_FIELD_SPEC, ClassName##Details, __VA_ARGS__)> \
+    {                                                                                       \
+        private:                                                                            \
+        using Base = data_structures::internal::EnumBitFieldsBase<                          \
+            ClassName, FOR_EACH_PAIR_CTX(BF_FIELD_SPEC, ClassName##Details, __VA_ARGS__)>;  \
+                                                                                            \
+        public:                                                                             \
+        using Base::Base;                                                                   \
+        using Base::operator=;                                                              \
+        using Base::get;                                                                    \
+        using Base::set;                                                                    \
+                                                                                            \
+        FOR_EACH_PAIR_CTX_SEP(SEMICOLON, BF_FIELD_TAG, ClassName##Details, __VA_ARGS__);    \
     }
 
 #endif  // LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_BITFIELD_HPP_

--- a/libs/libcontainers/include/data_structures/bitfield.hpp
+++ b/libs/libcontainers/include/data_structures/bitfield.hpp
@@ -1,0 +1,243 @@
+#ifndef LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_BITFIELD_HPP_
+#define LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_BITFIELD_HPP_
+
+#include <stddef.h>
+#include <bit.hpp>
+#include <data_structures/bit_array.hpp>
+#include <internal/macro.hpp>
+#include <tuple.hpp>
+#include <type_traits.hpp>
+
+namespace data_structures::internal
+{
+
+// Type-safe field tag
+template <typename Owner, std::size_t Index, std::size_t Width>
+struct BitFieldTag {
+    using owner_type                   = Owner;
+    static constexpr std::size_t index = Index;
+    static constexpr std::size_t width = Width;
+};
+
+// BitField specification
+template <typename Tag>
+struct BitFieldSpec {
+    using tag_type                     = Tag;
+    static constexpr std::size_t width = Tag::width;
+    static constexpr std::size_t index = Tag::index;
+};
+
+// Calculate offset for a field at Index
+template <std::size_t Index, typename... Specs>
+struct OffsetCalculator;
+
+template <std::size_t Index, typename First, typename... Rest>
+struct OffsetCalculator<Index, First, Rest...> {
+    static constexpr std::size_t value =
+        (Index == First::index) ? 0 : First::width + OffsetCalculator<Index, Rest...>::value;
+};
+
+template <std::size_t Index, typename First>
+struct OffsetCalculator<Index, First> {
+    static constexpr std::size_t value = (Index == First::index) ? 0 : First::width;
+};
+
+// Calculate total size in bits
+template <typename... Specs>
+struct TotalSize;
+
+template <typename First, typename... Rest>
+struct TotalSize<First, Rest...> {
+    static constexpr std::size_t value = First::width + TotalSize<Rest...>::value;
+};
+
+template <>
+struct TotalSize<> {
+    static constexpr std::size_t value = 0;
+};
+
+// Find spec by tag index
+template <std::size_t Index, typename... Specs>
+struct FindSpecByIndex;
+
+template <std::size_t Index, typename First, typename... Rest>
+struct FindSpecByIndex<Index, First, Rest...> {
+    static constexpr bool found = (First::index == Index);
+    using type = std::conditional_t<found, First, typename FindSpecByIndex<Index, Rest...>::type>;
+};
+
+template <std::size_t Index>
+struct FindSpecByIndex<Index> {
+    static constexpr bool found = false;
+    using type                  = void;
+};
+
+template <typename T>
+struct IsBitField : std::false_type {
+};
+
+template <typename Derived, typename... FieldSpecs>
+class EnumBitFieldsBase;
+
+template <typename Derived, typename... FieldSpecs>
+struct IsBitField<EnumBitFieldsBase<Derived, FieldSpecs...>> : std::true_type {
+};
+
+template <typename T>
+concept NotBitField = !IsBitField<std::remove_cvref_t<T>>::value;
+
+template <typename Derived, typename... FieldSpecs>
+class EnumBitFieldsBase
+{
+    public:
+    static constexpr std::size_t kTotalBits = TotalSize<FieldSpecs...>::value;
+
+    protected:
+    BitArray<kTotalBits> data_;
+
+    template <typename T, std::size_t Offset, std::size_t Width>
+    static constexpr T extract_bits(const BitArray<kTotalBits> &arr)
+    {
+        return arr.template GetRange<T, Offset, Width>();
+    }
+
+    template <typename T, std::size_t Offset, std::size_t Width>
+    static constexpr void insert_bits(BitArray<kTotalBits> &arr, T value)
+    {
+        arr.template SetRange<T, Offset, Width>(value);
+    }
+
+    public:
+    constexpr EnumBitFieldsBase() = default;
+
+    constexpr EnumBitFieldsBase(const EnumBitFieldsBase &) = default;
+
+    template <typename OtherDerived, typename... OtherSpecs>
+    constexpr EnumBitFieldsBase(const EnumBitFieldsBase<OtherDerived, OtherSpecs...> &other)
+        : data_(other.storage())
+    {
+        static_assert(
+            kTotalBits == EnumBitFieldsBase<OtherDerived, OtherSpecs...>::kTotalBits,
+            "BitField construction failed: Source and Destination must have the same total size in "
+            "bits."
+        );
+    }
+
+    template <NotBitField T>
+    constexpr explicit EnumBitFieldsBase(const T &value)
+    {
+        static_assert(
+            sizeof(T) == data_.kNumStorage,
+            "Raw Type construction failed: Size of input type must match BitField storage size."
+        );
+
+        data_ = std::bit_cast<BitArray<kTotalBits>>(value);
+    }
+
+    template <NotBitField T>
+    constexpr EnumBitFieldsBase &operator=(const T &value)
+    {
+        static_assert(
+            sizeof(T) == data_.kNumStorage,
+            "Raw Type assignment failed: Size of input type must match BitField storage size."
+        );
+
+        data_ = std::bit_cast<BitArray<kTotalBits>>(value);
+        return *this;
+    }
+
+    template <NotBitField T>
+    constexpr explicit operator T() const
+    {
+        static_assert(
+            sizeof(T) == data_.kNumStorage,
+            "Cast to Raw Type failed: Size of destination type must match BitField storage size."
+        );
+
+        return std::bit_cast<T>(data_);
+    }
+
+    template <typename OtherDerived, typename... OtherSpecs>
+    constexpr EnumBitFieldsBase &operator=(
+        const EnumBitFieldsBase<OtherDerived, OtherSpecs...> &other
+    )
+    {
+        static_assert(
+            kTotalBits == EnumBitFieldsBase<OtherDerived, OtherSpecs...>::kTotalBits,
+            "BitField assignment failed: Source and Destination bitfields must have the same total "
+            "size in bits."
+        );
+
+        this->data_ = other.storage();
+        return *this;
+    }
+
+    template <std::size_t Index>
+    static constexpr std::size_t offset_for()
+    {
+        return OffsetCalculator<Index, FieldSpecs...>::value;
+    }
+
+    template <typename Tag>
+    constexpr auto get() const
+    {
+        static_assert(std::is_same_v<typename Tag::owner_type, Derived>, "Invalid Tag used");
+        using Spec                   = typename FindSpecByIndex<Tag::index, FieldSpecs...>::type;
+        constexpr std::size_t offset = offset_for<Tag::index>();
+        constexpr std::size_t width  = Spec::width;
+        return extract_bits<std::size_t, offset, width>(data_);
+    }
+
+    template <typename Tag>
+    constexpr void set(std::size_t value)
+    {
+        static_assert(std::is_same_v<typename Tag::owner_type, Derived>, "Invalid Tag used");
+        using Spec                   = typename FindSpecByIndex<Tag::index, FieldSpecs...>::type;
+        constexpr std::size_t offset = offset_for<Tag::index>();
+        constexpr std::size_t width  = Spec::width;
+        insert_bits<std::size_t, offset, width>(data_, value);
+    }
+
+    constexpr const BitArray<kTotalBits> &storage() const { return data_; }
+    constexpr BitArray<kTotalBits> &storage() { return data_; }
+};
+
+}  // namespace data_structures::internal
+
+#define BF_ENUM_ENTRY(name, width) k##name
+
+#define BF_FIELD_TAG(ctx, name, width)                   \
+    using name = data_structures::internal::BitFieldTag< \
+        ctx::Owner, static_cast<std::size_t>(ctx::Index::k##name), width>
+
+#define BF_FIELD_SPEC(ctx, name, width)                                             \
+    data_structures::internal::BitFieldSpec<data_structures::internal::BitFieldTag< \
+        ctx::Owner, static_cast<std::size_t>(ctx::Index::k##name), width>>
+
+#define CREATE_BITFIELD(ClassName, ...)                                                      \
+    class ClassName;                                                                         \
+                                                                                             \
+    namespace ClassName##Details                                                             \
+    {                                                                                        \
+        using Owner = ClassName;                                                             \
+        enum class Index : std::size_t { FOR_EACH_PAIR(BF_ENUM_ENTRY, __VA_ARGS__), kLast }; \
+    }                                                                                        \
+                                                                                             \
+    class ClassName                                                                          \
+        : public data_structures::internal::EnumBitFieldsBase<                               \
+              ClassName, FOR_EACH_PAIR_CTX(BF_FIELD_SPEC, ClassName##Details, __VA_ARGS__)>  \
+    {                                                                                        \
+        private:                                                                             \
+        using Base = data_structures::internal::EnumBitFieldsBase<                           \
+            ClassName, FOR_EACH_PAIR_CTX(BF_FIELD_SPEC, ClassName##Details, __VA_ARGS__)>;   \
+                                                                                             \
+        public:                                                                              \
+        using Base::Base;                                                                    \
+        using Base::operator=;                                                               \
+        using Base::get;                                                                     \
+        using Base::set;                                                                     \
+                                                                                             \
+        FOR_EACH_PAIR_CTX_SEP(SEMICOLON, BF_FIELD_TAG, ClassName##Details, __VA_ARGS__);     \
+    }
+
+#endif  // LIBS_LIBCONTAINERS_INCLUDE_DATA_STRUCTURES_BITFIELD_HPP_

--- a/libs/libcpp/include/bit.hpp
+++ b/libs/libcpp/include/bit.hpp
@@ -1,5 +1,5 @@
-#ifndef ALKOS_LIBC_INCLUDE_EXTENSIONS_BIT_HPP_
-#define ALKOS_LIBC_INCLUDE_EXTENSIONS_BIT_HPP_
+#ifndef LIBS_LIBCPP_INCLUDE_BIT_HPP_
+#define LIBS_LIBCPP_INCLUDE_BIT_HPP_
 
 #include <bits_ext.hpp>
 #include <concepts.hpp>
@@ -168,9 +168,21 @@ constexpr FAST_CALL T bit_ceil(T x) noexcept
     return kLsb<T> << std::bit_width(T(x - static_cast<T>(1)));
 }
 
+// ------------------------------
+// std::bit_cast
+// ------------------------------
+
+template <class To, class From>
+constexpr To bit_cast(const From &from) noexcept
+    requires(sizeof(To) == sizeof(From)) && std::is_trivially_copyable_v<To> &&
+            std::is_trivially_copyable_v<From>
+{
+    return __builtin_bit_cast(To, from);
+}
+
 TODO_LIBCPP_COMPLIANCE
 // TODO: Implement other functions from standard
 
 }  // namespace std
 
-#endif  // ALKOS_LIBC_INCLUDE_EXTENSIONS_BIT_HPP_
+#endif  // LIBS_LIBCPP_INCLUDE_BIT_HPP_

--- a/libs/libcpp/include/bits_ext.hpp
+++ b/libs/libcpp/include/bits_ext.hpp
@@ -1,5 +1,5 @@
-#ifndef ALKOS_LIBC_INCLUDE_EXTENSIONS_BITS_EXT_HPP_
-#define ALKOS_LIBC_INCLUDE_EXTENSIONS_BITS_EXT_HPP_
+#ifndef LIBS_LIBCPP_INCLUDE_BITS_EXT_HPP_
+#define LIBS_LIBCPP_INCLUDE_BITS_EXT_HPP_
 
 #include <stdint.h>
 #include "assert.h"
@@ -96,6 +96,12 @@ template <std::unsigned_integral NumT>
 FAST_CALL NumT &SetBit(NumT &num, const u16 bit)
 {
     return num |= kLsb<NumT> << bit;
+}
+
+template <u16 kBit, std::unsigned_integral NumT>
+FAST_CALL constexpr bool GetBit(const NumT num)
+{
+    return num & kSingleBit<NumT, kBit>;
 }
 
 template <std::unsigned_integral NumT>
@@ -214,4 +220,4 @@ FAST_CALL constexpr bool IsPowerOfTwo(const NumT n)
     return n > 0 && (n & (n - 1)) == 0;
 }
 
-#endif  // ALKOS_LIBC_INCLUDE_EXTENSIONS_BITS_EXT_HPP_
+#endif  // LIBS_LIBCPP_INCLUDE_BITS_EXT_HPP_

--- a/libs/libcpp/include/internal/macro.hpp
+++ b/libs/libcpp/include/internal/macro.hpp
@@ -1,0 +1,37 @@
+#ifndef LIBS_LIBCPP_INCLUDE_INTERNAL_MACRO_HPP_
+#define LIBS_LIBCPP_INCLUDE_INTERNAL_MACRO_HPP_
+
+// https://www.scs.stanford.edu/~dm/blog/va-opt.html
+#define PARENS      ()
+#define SEMICOLON() ;
+#define COMMA()     ,
+
+#define EXPAND(...)  EXPAND4(EXPAND4(EXPAND4(EXPAND4(__VA_ARGS__))))
+#define EXPAND4(...) EXPAND3(EXPAND3(EXPAND3(EXPAND3(__VA_ARGS__))))
+#define EXPAND3(...) EXPAND2(EXPAND2(EXPAND2(EXPAND2(__VA_ARGS__))))
+#define EXPAND2(...) EXPAND1(EXPAND1(EXPAND1(EXPAND1(__VA_ARGS__))))
+#define EXPAND1(...) __VA_ARGS__
+
+#define FOR_EACH(macro, ...) __VA_OPT__(EXPAND(FOR_EACH_HELPER(macro, __VA_ARGS__)))
+#define FOR_EACH_HELPER(macro, a1, ...) \
+    macro(a1) __VA_OPT__(, FOR_EACH_AGAIN PARENS(macro, __VA_ARGS__))
+#define FOR_EACH_AGAIN() FOR_EACH_HELPER
+
+#define FOR_EACH_PAIR_SEP(sep, macro, ...) \
+    __VA_OPT__(EXPAND(FOR_EACH_PAIR_SEP_HELPER(sep, macro, __VA_ARGS__)))
+#define FOR_EACH_PAIR_SEP_HELPER(sep, macro, a1, a2, ...) \
+    macro(a1, a2) __VA_OPT__(sep PARENS FOR_EACH_PAIR_SEP_AGAIN PARENS(sep, macro, __VA_ARGS__))
+#define FOR_EACH_PAIR_SEP_AGAIN() FOR_EACH_PAIR_SEP_HELPER
+
+#define FOR_EACH_PAIR(macro, ...) FOR_EACH_PAIR_SEP(COMMA, macro, __VA_ARGS__)
+
+#define FOR_EACH_PAIR_CTX_SEP(sep, macro, ctx, ...) \
+    __VA_OPT__(EXPAND(FOR_EACH_PAIR_CTX_SEP_HELPER(sep, macro, ctx, __VA_ARGS__)))
+#define FOR_EACH_PAIR_CTX_SEP_HELPER(sep, macro, ctx, a1, a2, ...) \
+    macro(ctx, a1, a2)                                             \
+        __VA_OPT__(sep PARENS FOR_EACH_PAIR_CTX_SEP_AGAIN PARENS(sep, macro, ctx, __VA_ARGS__))
+#define FOR_EACH_PAIR_CTX_SEP_AGAIN() FOR_EACH_PAIR_CTX_SEP_HELPER
+
+#define FOR_EACH_PAIR_CTX(macro, ctx, ...) FOR_EACH_PAIR_CTX_SEP(COMMA, macro, ctx, __VA_ARGS__)
+
+#endif  // LIBS_LIBCPP_INCLUDE_INTERNAL_MACRO_HPP_


### PR DESCRIPTION

Introduces a new `BitField` utility for defining and accessing bitfields with named, type-safe fields.
Enhances `BitArray` with `GetRange` and `SetRange` methods to efficiently manipulate bit ranges, including boundary-crossing scenarios. These methods are fundamental for `BitField`'s internal storage.
Adds `std::bit_cast` for safe reinterpretation of object representations, enabling `BitField` to convert to/from raw integer types.
Includes new internal macros to support the `CREATE_BITFIELD` macro.
Adds comprehensive tests for both `BitArray` range operations and the new `BitField` utility.