### PR TITLE
Kryczkal/vmm coherency

### DIFF
--- a/kernel/arch/x86_64/CMakeLists.txt
+++ b/kernel/arch/x86_64/CMakeLists.txt
@@ -58,7 +58,7 @@ alkos_register_runtime_environment(
     QEMU_COMMAND
         "qemu-system-x86_64"
     QEMU_NORMAL_FLAGS
-    "-serial stdio -enable-kvm -cpu max -display default,show-cursor=on -k en-us -m 4G -smp sockets=1,cores=4,threads=1 -no-reboot"
+        "-serial stdio -enable-kvm -cpu max -display default,show-cursor=on -k en-us -m 4G -smp sockets=1,cores=4,threads=1 -no-reboot"
     QEMU_TEST_FLAGS
         "-serial stdio -enable-kvm -cpu max -display none -m 4G -smp sockets=1,cores=4,threads=1 -no-reboot"
     MODULES

--- a/kernel/arch/x86_64/src/drivers/apic/io_apic.cpp
+++ b/kernel/arch/x86_64/src/drivers/apic/io_apic.cpp
@@ -1,4 +1,5 @@
 #include "drivers/apic/io_apic.hpp"
+#include <mem/types.hpp>
 #include "drivers/apic/local_apic.hpp"
 
 #include <bit.hpp>
@@ -35,9 +36,10 @@ IoApic::IoApic(const u8 id, const u32 address, const u32 gsi_base)
 {
     ASSERT_NOT_ZERO(address);
 
-    TODO_WHEN_VMEM_WORKS
-    /* TODO: Map the address first, currently identity */
-    virtual_address_ = physical_address_;
+    /* Map the address first */
+    virtual_address_ = reinterpret_cast<uintptr_t>(
+        Mem::PhysToVirt(reinterpret_cast<void *>(static_cast<uintptr_t>(physical_address_)))
+    );
 
     version_ = static_cast<u8>(ReadRegister(kIoApicVerReg)); /* Removes upper bits */
     num_entries_ =

--- a/kernel/arch/x86_64/src/drivers/apic/local_apic.hpp
+++ b/kernel/arch/x86_64/src/drivers/apic/local_apic.hpp
@@ -5,8 +5,8 @@
 #include <cpuid.h>
 #include <bit.hpp>
 #include <defines.hpp>
+#include <mem/types.hpp>
 #include <todo.hpp>
-#include <types.hpp>
 #include "cpu/msrs.hpp"
 #include "hal/impl/constants.hpp"
 #include "include/memory_io.hpp"
@@ -345,12 +345,8 @@ class LocalApic
     template <class InputT>
     FAST_CALL void WriteRegister(const u32 offset, const InputT value)
     {
-        TODO_WHEN_VMEM_WORKS
         WriteMemoryIo<u32>(
-            reinterpret_cast<byte *>(
-                GetPhysicalAddressOnCore()
-            ),  // TODO : REPLACE WITH VIRTUAL ADDRESS
-            offset, value
+            Mem::PhysToVirt(reinterpret_cast<byte *>(GetPhysicalAddressOnCore())), offset, value
         );
     }
 
@@ -365,12 +361,8 @@ class LocalApic
     template <class RetT = u32>
     FAST_CALL RetT ReadRegister(const u32 offset)
     {
-        TODO_WHEN_VMEM_WORKS
         return ReadMemoryIo<u32, RetT>(
-            reinterpret_cast<byte *>(
-                GetPhysicalAddressOnCore()
-            ),  // TODO : REPLACE WITH VIRTUAL ADDRESS
-            offset
+            Mem::PhysToVirt(reinterpret_cast<byte *>(GetPhysicalAddressOnCore())), offset
         );
     }
 

--- a/kernel/arch/x86_64/src/drivers/hpet/hpet.hpp
+++ b/kernel/arch/x86_64/src/drivers/hpet/hpet.hpp
@@ -4,6 +4,7 @@
 #include <uacpi/acpi.h>
 #include <array.hpp>
 #include <data_structures/bit_array.hpp>
+#include <mem/types.hpp>
 #include <time.hpp>
 #include <todo.hpp>
 #include <types.hpp>
@@ -215,17 +216,17 @@ class Hpet final
     template <class InputT>
     FORCE_INLINE_F void WriteRegister(const u32 offset, const InputT value)
     {
-        TODO_WHEN_VMEM_WORKS
-        // TODO : REPLACE WITH VIRTUAL ADDRESS
-        WriteMemoryIo<u64>(reinterpret_cast<byte *>(GetPhysicalAddress()), offset, value);
+        WriteMemoryIo<u64>(
+            Mem::PhysToVirt(reinterpret_cast<byte *>(GetPhysicalAddress())), offset, value
+        );
     }
 
     template <class RetT>
     FORCE_INLINE_F RetT ReadRegister(const u32 offset) const
     {
-        TODO_WHEN_VMEM_WORKS
-        // TODO : REPLACE WITH VIRTUAL ADDRESS
-        return ReadMemoryIo<u64, RetT>(reinterpret_cast<byte *>(GetPhysicalAddress()), offset);
+        return ReadMemoryIo<u64, RetT>(
+            Mem::PhysToVirt(reinterpret_cast<byte *>(GetPhysicalAddress())), offset
+        );
     }
 
     // ------------------------------

--- a/kernel/arch/x86_64/src/hal/impl/core.cpp
+++ b/kernel/arch/x86_64/src/hal/impl/core.cpp
@@ -15,13 +15,14 @@ void Core::EnableCore()
 
 void arch::InitializeCoreLocal()
 {
-    auto core_local = static_cast<hardware::CoreLocal *>(GetCoreLocalData());
+    auto *core_local = static_cast<hardware::CoreLocal *>(GetCoreLocalData());
 
     cpu::DefaultGdtInit(core_local->gdt, reinterpret_cast<u64>(&core_local->tss));
     core_local->gdtr.limit = sizeof(cpu::GDT) - 1;
     core_local->gdtr.base  = reinterpret_cast<u64>(&core_local->gdt);
 
     GdtFlush(&core_local->gdtr, cpu::GDT::kKernelCodeSelector, cpu::GDT::kKernelDataSelector);
+    SetCoreLocalData(core_local);
     cpu::LoadTss(cpu::GDT::kTssSelector);
 
     DEBUG_INFO_HARDWARE(

--- a/kernel/arch/x86_64/src/hal/impl/interrupts.cpp
+++ b/kernel/arch/x86_64/src/hal/impl/interrupts.cpp
@@ -40,7 +40,6 @@ void Interrupts::FirstStageInit()
     InitPic8259(kIrq1Offset, kIrq2Offset);
     MapToLogicalInterrupts_();
     SetupPicAsDefaultDriver_();
-    // trace::AdvanceTracingStage();
     InitializeDefaultIdt_();
 }
 

--- a/kernel/arch/x86_64/src/hal/impl/interrupts.cpp
+++ b/kernel/arch/x86_64/src/hal/impl/interrupts.cpp
@@ -40,7 +40,7 @@ void Interrupts::FirstStageInit()
     InitPic8259(kIrq1Offset, kIrq2Offset);
     MapToLogicalInterrupts_();
     SetupPicAsDefaultDriver_();
-    trace::AdvanceTracingStage();
+    // trace::AdvanceTracingStage();
     InitializeDefaultIdt_();
 }
 

--- a/kernel/arch/x86_64/src/hal/impl/mmu.cpp
+++ b/kernel/arch/x86_64/src/hal/impl/mmu.cpp
@@ -44,10 +44,7 @@ void FreeTableRecursive(PPtr<void> table_phys, PageMetaTable &pmt, BitmapPmm &pm
 
     for (auto &entry : *table_virt) {
         if (entry.IsPresent()) {
-            bool is_huge = false;
-            if constexpr (kLevel > 1) {
-                is_huge = entry.page_size;
-            }
+            bool is_huge = entry.IsHuge();
 
             if constexpr (kLevel > 1) {
                 if (!is_huge) {
@@ -82,7 +79,7 @@ void ReconstructRecursive(PPtr<void> table_phys, PageMeta *parent, PageMetaTable
         if (entry.IsPresent()) {
             ref_count++;
             if constexpr (kLevel > 1) {
-                if (!entry.page_size) {
+                if (!entry.IsHuge()) {
                     PPtr<void> child_phys = reinterpret_cast<PPtr<void>>(entry.GetNextLevelTable());
                     ReconstructRecursive<kLevel - 1>(child_phys, &meta, pmt);
                 }

--- a/kernel/arch/x86_64/src/hal/impl/mmu.cpp
+++ b/kernel/arch/x86_64/src/hal/impl/mmu.cpp
@@ -15,6 +15,7 @@ namespace
 {
 
 // Helper to get PageMeta from a physical pointer to a table/page
+// Used by Map/UnMap where MemoryModule is fully initialized
 PageMeta &GetPageMeta(PPtr<void> phys_ptr)
 {
     auto *aligned_phys = AlignDown(phys_ptr, hal::kPageSizeBytes);
@@ -26,6 +27,70 @@ PageMeta &GetPageMetaFromVirt(VPtr<void> virt_ptr)
 {
     auto *phys_ptr = VirtToPhys(virt_ptr);
     return GetPageMeta(phys_ptr);
+}
+
+// Helper to get PageMeta using explicit PageMetaTable (safe during initialization)
+PageMeta &GetPageMeta(PPtr<void> phys_ptr, PageMetaTable &pmt)
+{
+    auto *aligned_phys = AlignDown(phys_ptr, hal::kPageSizeBytes);
+    return pmt.GetPageMeta(aligned_phys);
+}
+
+// Helper to recursively free page table frames
+template <size_t kLevel>
+void FreeTableRecursive(PPtr<void> table_phys, PageMetaTable &pmt, BitmapPmm &pmm)
+{
+    auto *table_virt = reinterpret_cast<PageMapTable<kLevel> *>(PhysToVirt(table_phys));
+
+    for (auto &entry : *table_virt) {
+        if (entry.IsPresent()) {
+            bool is_huge = false;
+            if constexpr (kLevel > 1) {
+                is_huge = entry.page_size;
+            }
+
+            if constexpr (kLevel > 1) {
+                if (!is_huge) {
+                    PPtr<void> child_phys = reinterpret_cast<PPtr<void>>(entry.GetNextLevelTable());
+                    FreeTableRecursive<kLevel - 1>(child_phys, pmt, pmm);
+                }
+            }
+            // If it is a leaf (Level 1, or Huge Level 2/3), we do NOTHING.
+            // We are only destroying the mapping structure, not the memory it points to.
+        }
+    }
+
+    // Now free the table frame itself
+    pmm.Free(reinterpret_cast<PPtr<Page>>(table_phys));
+
+    // Invalidate metadata
+    auto &meta = GetPageMeta(table_phys, pmt);
+    meta.type  = PageMetaType::Dummy;
+}
+
+template <size_t kLevel>
+void ReconstructRecursive(PPtr<void> table_phys, PageMeta *parent, PageMetaTable &pmt)
+{
+    // Initialize metadata for the current table frame
+    auto &meta = GetPageMeta(table_phys, pmt);
+    meta.InitPageTable(kLevel, parent);
+
+    auto *table_virt = reinterpret_cast<PageMapTable<kLevel> *>(PhysToVirt(table_phys));
+
+    u16 ref_count = 0;
+    for (const auto &entry : *table_virt) {
+        if (entry.IsPresent()) {
+            ref_count++;
+            if constexpr (kLevel > 1) {
+                if (!entry.page_size) {
+                    PPtr<void> child_phys = reinterpret_cast<PPtr<void>>(entry.GetNextLevelTable());
+                    ReconstructRecursive<kLevel - 1>(child_phys, &meta, pmt);
+                }
+                // If page_size is set, then it's a huge page
+            }
+        }
+    }
+    meta.data.page_table.ref_count = ref_count;
 }
 
 }  // namespace
@@ -260,4 +325,33 @@ expected<PPtr<void>, MemError> Mmu::Translate(VPtr<AddressSpace> as, VPtr<void> 
     }
 
     return pme_l1->GetFrameAddress();
+}
+
+void Mmu::ReconstructAddressSpace(Mem::PPtr<void> root_page_table, Mem::PageMetaTable &pmt)
+{
+    ReconstructRecursive<4>(root_page_table, nullptr, pmt);
+}
+
+void Mmu::UnmapLowerHalf(
+    Mem::PPtr<void> root_page_table, Mem::PageMetaTable &pmt, Mem::BitmapPmm &pmm, hal::Tlb &tlb
+)
+{
+    auto *pml4_virt = reinterpret_cast<PageMapTable<4> *>(PhysToVirt(root_page_table));
+    auto &pml4_meta = GetPageMeta(root_page_table, pmt);
+
+    constexpr size_t kLowerHalfLimit = 256;
+    for (size_t i = 0; i < kLowerHalfLimit; ++i) {
+        auto &entry = (*pml4_virt)[i];
+        if (entry.IsPresent()) {
+            // Free the table the entry points to
+            PPtr<void> pdpt_phys = reinterpret_cast<PPtr<void>>(entry.GetNextLevelTable());
+            FreeTableRecursive<3>(pdpt_phys, pmt, pmm);
+
+            // Free the entry
+            *reinterpret_cast<u64 *>(&entry) = 0;
+        }
+    }
+
+    // Flush TLB to ensure CPU doesn't retain old mappings
+    tlb.FlushAll();
 }

--- a/kernel/arch/x86_64/src/hal/impl/mmu.hpp
+++ b/kernel/arch/x86_64/src/hal/impl/mmu.hpp
@@ -34,6 +34,12 @@ class Mmu : public MmuAPI
 
     void DestroyRootPageMapTable(Mem::PPtr<void> pmt4) { (void)pmt4; }
 
+    void ReconstructAddressSpace(Mem::PPtr<void> root_page_table, Mem::PageMetaTable &pmt);
+
+    void UnmapLowerHalf(
+        Mem::PPtr<void> root_page_table, Mem::PageMetaTable &pmt, Mem::BitmapPmm &pmm, hal::Tlb &tlb
+    );
+
     private:
     template <size_t kLevel>
     u64 PmeIdx(Mem::VPtr<void> vaddr);

--- a/kernel/arch/x86_64/src/kernel/init.cpp
+++ b/kernel/arch/x86_64/src/kernel/init.cpp
@@ -75,6 +75,5 @@ void ArchInit(const RawBootArguments &)
     EnableHardwareInterrupts();
 
     DEBUG_INFO_BOOT("Leaving ArchInit");
-    trace::Flush();
 }
 }  // namespace arch

--- a/kernel/arch/x86_64/src/kernel/init.cpp
+++ b/kernel/arch/x86_64/src/kernel/init.cpp
@@ -70,6 +70,8 @@ void ArchInit(const RawBootArguments &)
     hal::SetCoreLocalData(&g_CoreLocal);
     InitializeCoreLocal();
 
+    trace::AdvanceTracingStage();
+
     EnableHardwareInterrupts();
 
     DEBUG_INFO_BOOT("Leaving ArchInit");

--- a/kernel/arch/x86_64/src/kernel/init.cpp
+++ b/kernel/arch/x86_64/src/kernel/init.cpp
@@ -75,5 +75,6 @@ void ArchInit(const RawBootArguments &)
     EnableHardwareInterrupts();
 
     DEBUG_INFO_BOOT("Leaving ArchInit");
+    trace::Flush();
 }
 }  // namespace arch

--- a/kernel/arch/x86_64/src/mem/page_map.hpp
+++ b/kernel/arch/x86_64/src/mem/page_map.hpp
@@ -93,6 +93,8 @@ struct PageMapEntry<4> {
 
     NODISCARD bool IsPresent() const { return present; }
 
+    NODISCARD bool IsHuge() const { return false; }
+
     NODISCARD Mem::PPtr<PageMapTable<3>> GetNextLevelTable() const
     {
         return Mem::UptrToPtr<PageMapTable<3>>(static_cast<u64>(frame) << 12);
@@ -131,6 +133,8 @@ struct PageMapEntry<3> {
 
     NODISCARD bool IsPresent() const { return present; }
 
+    NODISCARD bool IsHuge() const { return page_size; }
+
     NODISCARD Mem::PPtr<PageMapTable<2>> GetNextLevelTable() const
     {
         return Mem::UptrToPtr<PageMapTable<2>>(static_cast<u64>(frame) << 12);
@@ -167,6 +171,8 @@ struct PageMapEntry<3, kHugePage> {
     // Accessors
 
     NODISCARD bool IsPresent() const { return present; }
+
+    NODISCARD bool IsHuge() const { return true; }
 
     NODISCARD Mem::PPtr<void> GetFrameAddress() const
     {
@@ -205,6 +211,8 @@ struct PageMapEntry<2> {
 
     NODISCARD bool IsPresent() const { return present; }
 
+    NODISCARD bool IsHuge() const { return page_size; }
+
     NODISCARD Mem::PPtr<PageMapTable<1>> GetNextLevelTable() const
     {
         return Mem::UptrToPtr<PageMapTable<1>>(static_cast<u64>(frame) << 12);
@@ -241,6 +249,8 @@ struct PageMapEntry<2, kHugePage> {
     // Accessors
 
     NODISCARD bool IsPresent() const { return present; }
+
+    NODISCARD bool IsHuge() const { return true; }
 
     NODISCARD Mem::PPtr<void> GetFrameAddress() const
     {
@@ -280,6 +290,8 @@ struct PageMapEntry<1> {
     // Accessors
 
     NODISCARD bool IsPresent() const { return present; }
+
+    NODISCARD bool IsHuge() const { return false; }
 
     NODISCARD Mem::PPtr<void> GetFrameAddress() const
     {

--- a/kernel/src/hal/api/mmu.hpp
+++ b/kernel/src/hal/api/mmu.hpp
@@ -104,6 +104,9 @@ struct MmuAPI {
      * It recursively frees the page tables used for this mapping but does NOT
      * free the underlying physical frames (leaf nodes) mapped by them.
      *
+     * @note THIS IS TO BE USED DIRECTLY AFTER RECONSTRUCTING BITMAP PMM, BEFORE BUDDY PMM
+     * IS INITIALIZED
+     *
      * @param root_page_table Physical pointer to the top-level page table.
      * @param pmt Reference to the PageMetaTable instance.
      * @param pmm Reference to the BitmapPmm instance (for freeing tables).

--- a/kernel/src/hal/api/mmu.hpp
+++ b/kernel/src/hal/api/mmu.hpp
@@ -9,7 +9,14 @@ namespace Mem
 {
 
 class AddressSpace;
+class PageMetaTable;
+class BitmapPmm;
 
+}  // namespace Mem
+
+namespace hal
+{
+class Tlb;
 }
 
 namespace arch
@@ -77,6 +84,34 @@ struct MmuAPI {
      *
      */
     void CleanRootPageMapTable(Mem::PPtr<void> root_page_table);
+
+    /**
+     * @brief Reconstructs the PageMeta metadata for an existing page table hierarchy.
+     *
+     * This is used during kernel initialization to synchronize the software metadata
+     * (PageMeta) with the hardware page tables set up by the bootloader. It recursively
+     * walks the tables, initializing PageMeta types and reference counts.
+     *
+     * @param root_page_table Physical pointer to the top-level page table.
+     * @param pmt Reference to the PageMetaTable instance.
+     */
+    void ReconstructAddressSpace(Mem::PPtr<void> root_page_table, Mem::PageMetaTable &pmt);
+
+    /**
+     * @brief Unmaps the lower half of the address space (entries 0-255 of PML4).
+     *
+     * This removes the identity mapping established by the bootloader.
+     * It recursively frees the page tables used for this mapping but does NOT
+     * free the underlying physical frames (leaf nodes) mapped by them.
+     *
+     * @param root_page_table Physical pointer to the top-level page table.
+     * @param pmt Reference to the PageMetaTable instance.
+     * @param pmm Reference to the BitmapPmm instance (for freeing tables).
+     * @param tlb Reference to the TLB instance (for flushing).
+     */
+    void UnmapLowerHalf(
+        Mem::PPtr<void> root_page_table, Mem::PageMetaTable &pmt, Mem::BitmapPmm &pmm, hal::Tlb &tlb
+    );
 };
 
 }  // namespace arch

--- a/kernel/src/hal/panic.hpp
+++ b/kernel/src/hal/panic.hpp
@@ -27,6 +27,7 @@ WRAP_CALL void KernelPanic(const char *msg)
 template <typename... Args>
 FAST_CALL NO_RET void KernelPanicFormat(const char *fmt, Args... args)
 {
+    TRACE_FATAL_GENERAL("[ KERNEL PANIC ]");
     TRACE_FATAL_GENERAL(fmt, args...);
     arch::KernelPanic();
 

--- a/kernel/src/init.cpp
+++ b/kernel/src/init.cpp
@@ -23,12 +23,8 @@ void KernelInit(const hal::RawBootArguments &raw_args)
     hal::TerminalInit();
     hal::ArchInit(raw_args);
 
-    TRACE_INFO_GENERAL("Sanitizing Boot Args");
-    trace::Flush();
     BootArguments args = SanitizeBootArgs(raw_args);
 
-    TRACE_INFO_GENERAL("MemoryModule Init");
-    trace::Flush();
     MemoryModule::Init(args);
 
     /* GCC CXX provided function initializing global constructors */

--- a/kernel/src/init.cpp
+++ b/kernel/src/init.cpp
@@ -23,8 +23,12 @@ void KernelInit(const hal::RawBootArguments &raw_args)
     hal::TerminalInit();
     hal::ArchInit(raw_args);
 
+    TRACE_INFO_GENERAL("Sanitizing Boot Args");
+    trace::Flush();
     BootArguments args = SanitizeBootArgs(raw_args);
 
+    TRACE_INFO_GENERAL("MemoryModule Init");
+    trace::Flush();
     MemoryModule::Init(args);
 
     /* GCC CXX provided function initializing global constructors */

--- a/kernel/src/kernel.cpp
+++ b/kernel/src/kernel.cpp
@@ -52,12 +52,12 @@ static void KernelRun()
     }
 }
 
-extern "C" void KernelMain(const hal::RawBootArguments *raw_args)
+extern "C" void KernelMain(const Mem::PPtr<hal::RawBootArguments> raw_args)
 {
     ASSERT_NOT_NULL(raw_args, "Raw boot arguments are null");
     TRACE_INFO_GENERAL("Running kernel initialization...");
 
-    KernelInit(*raw_args);
+    KernelInit(*Mem::PhysToVirt(raw_args));
 
     if constexpr (FeatureEnabled<FeatureFlag::kRunTestMode>) {
         TRACE_INFO_GENERAL("Running tests...");

--- a/kernel/src/mem/phys/mngr/buddy.cpp
+++ b/kernel/src/mem/phys/mngr/buddy.cpp
@@ -6,6 +6,8 @@
 #include "mem/page_meta_table.hpp"
 #include "mem/phys/mngr/bitmap.hpp"
 
+#include "trace_framework.hpp"
+
 using namespace Mem;
 using B = BuddyPmm;
 
@@ -169,7 +171,7 @@ void B::Free(PPtr<Page> page)
     size_t pfn     = PageFrameNumber(page);
     PageMeta &meta = pmt_->GetPageMeta(pfn);
 
-    ASSERT_EQ(
+    R_ASSERT_EQ(
         meta.type, PageMetaType::Allocated, "Double free detected or freeing an invalid page!"
     );
 

--- a/kernel/src/mem/phys/mngr/buddy.cpp
+++ b/kernel/src/mem/phys/mngr/buddy.cpp
@@ -6,8 +6,6 @@
 #include "mem/page_meta_table.hpp"
 #include "mem/phys/mngr/bitmap.hpp"
 
-#include "trace_framework.hpp"
-
 using namespace Mem;
 using B = BuddyPmm;
 

--- a/kernel/src/mem/virt/page_fault.cpp
+++ b/kernel/src/mem/virt/page_fault.cpp
@@ -22,7 +22,7 @@ void PageFaultHandler(intr::LitExcEntry &, hal::ExceptionData *data)
     auto &as           = MemoryModule::Get().GetKernelAddressSpace();
     auto area_or_error = as.FindArea(f_ptr);
     if (!area_or_error) {
-        KernelPanicFormat("Page fault in unmapped memory at 0x%p", f_ptr);
+        KernelPanicFormat("Page fault in unmapped memory at %p", f_ptr);
         return;
     }
     VPtr<VMemArea> vma_ptr = *area_or_error;
@@ -30,7 +30,7 @@ void PageFaultHandler(intr::LitExcEntry &, hal::ExceptionData *data)
 
     if (!err.present) {  // Page just wasn't there
         if (err.write && !vma.flags.writable) {
-            hal::KernelPanicFormat("Write to read-only memory area at 0x%p", f_ptr);
+            hal::KernelPanicFormat("Write to read-only memory area at %p", f_ptr);
             return;
         }
 
@@ -58,7 +58,7 @@ void PageFaultHandler(intr::LitExcEntry &, hal::ExceptionData *data)
             );
         } else {
             hal::KernelPanicFormat(
-                "Unsupported VMA type %d at 0x%p", static_cast<int>(vma.type), f_ptr
+                "Unsupported VMA type %d at %p", static_cast<int>(vma.type), f_ptr
             );
             return;
         }
@@ -76,11 +76,11 @@ void PageFaultHandler(intr::LitExcEntry &, hal::ExceptionData *data)
         auto map_res = mmu.Map(&as, AlignDown(f_ptr, hal::kPageSizeBytes), map_to, page_flags);
 
         if (!map_res) {
-            hal::KernelPanicFormat("Failed to map page for address 0x%p", f_ptr);
+            hal::KernelPanicFormat("Failed to map page for address %p", f_ptr);
         }
 
         TRACE_INFO_GENERAL(
-            "Handled page fault at 0x%p by mapping to physical page at 0x%p", f_ptr, map_to
+            "Handled page fault at %p by mapping to physical page at %p", f_ptr, map_to
         );
         return;
     }

--- a/kernel/src/modules/memory.cpp
+++ b/kernel/src/modules/memory.cpp
@@ -28,7 +28,7 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
     // Prune whatever bootloader had left over
     TRACE_INFO_MEMORY("Unmapping lower half of memory");
     {
-        Mmu_.UnmapLowerHalf(args.root_page_table, PageMetaTable_, BitmapPmm_, Tlb_);
+        // Mmu_.UnmapLowerHalf(args.root_page_table, PageMetaTable_, BitmapPmm_, Tlb_);
     }
 
     constexpr size_t kInitialBuddyPagesLimit = 4096;  // 16MB

--- a/kernel/src/modules/memory.cpp
+++ b/kernel/src/modules/memory.cpp
@@ -17,7 +17,6 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
     : KernelAddressSpace_(args.root_page_table)
 {
     DEBUG_INFO_MEMORY("MemoryModule::MemoryModule()");
-    trace::Flush();
 
     // Prepare
     const size_t total_pages    = args.total_page_frames;
@@ -25,21 +24,14 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
     data_structures::BitMapView bmv{mem_bitmap, total_pages};
 
     // Init
-    TRACE_INFO_MEMORY("Bitmap");
-    trace::Flush();
     BitmapPmm_.Init(bmv);
 
-    TRACE_INFO_MEMORY("Pmt");
-    trace::Flush();
     PageMetaTable_.Init(args.total_page_frames, BitmapPmm_);
 
     // Prune whatever bootloader had left over
     TRACE_INFO_MEMORY("Unmapping lower half of memory");
-    trace::Flush();
     {
-        QemuTerminalWriteString("test1\n");
         Mmu_.UnmapLowerHalf(args.root_page_table, PageMetaTable_, BitmapPmm_, Tlb_);
-        QemuTerminalWriteString("test2\n");
     }
 
     constexpr size_t kInitialBuddyPagesLimit = 4096;  // 16MB
@@ -47,21 +39,12 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
     // This limit is for speed of boot. This operation should have
     // a follow up once kernel is booted, and we have another CPU, we
     // could offload this operation to.
-    QemuTerminalWriteString("test3.1\n");
-    TRACE_INFO_MEMORY("Buddy Init");
-    QemuTerminalWriteString("test3.2\n");
-    trace::Flush();
     BuddyPmm_.Init(BitmapPmm_, PageMetaTable_, kInitialBuddyPagesLimit);
-    TRACE_INFO_MEMORY("Buddy End");
-    QemuTerminalWriteString("test4\n");
-    trace::Flush();
 
     TRACE_INFO_MEMORY("Reconstructing page table metadata from root: 0x%p", args.root_page_table);
-    trace::Flush();
     // Mmu_.ReconstructAddressSpace(args.root_page_table, PageMetaTable_);
 
     SlabAllocator_.Init(BuddyPmm_);
-    QemuTerminalWriteString("test5\n");
 
     Heap_.Init(PageMetaTable_, BuddyPmm_, SlabAllocator_);
 

--- a/kernel/src/modules/memory.cpp
+++ b/kernel/src/modules/memory.cpp
@@ -25,6 +25,12 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
 
     PageMetaTable_.Init(args.total_page_frames, BitmapPmm_);
 
+    // Prune whatever bootloader had left over
+    TRACE_INFO_MEMORY("Unmapping lower half of memory");
+    {
+        // Mmu_.UnmapLowerHalf(args.root_page_table, PageMetaTable_, BitmapPmm_, Tlb_);
+    }
+
     constexpr size_t kInitialBuddyPagesLimit = 4096;  // 16MB
     // Note: Initializing buddy with all pages is a slow operation.
     // This limit is for speed of boot. This operation should have
@@ -32,23 +38,52 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
     // could offload this operation to.
     BuddyPmm_.Init(BitmapPmm_, PageMetaTable_, kInitialBuddyPagesLimit);
 
-    // Initialize metadata for the Kernel PML4 (Root Page Table).
-    // The bootloader passes it, so it's already allocated but its metadata
-    // needs to be correctly set as a PageTable to support MMU operations.
-    {
-        auto &root_meta = PageMetaTable_.GetPageMeta(args.root_page_table);
-
-        // Initialize as a Level 4 page table with no parent.
-        // We set ref_count to 1 to represent the kernel's static presence and prevent freeing.
-        root_meta.InitPageTable(4, nullptr);
-        root_meta.data.page_table.ref_count = 1;
-    }
+    TRACE_INFO_MEMORY("Reconstructing page table metadata from root: 0x%p", args.root_page_table);
+    // Mmu_.ReconstructAddressSpace(args.root_page_table, PageMetaTable_);
 
     SlabAllocator_.Init(BuddyPmm_);
 
     Heap_.Init(PageMetaTable_, BuddyPmm_, SlabAllocator_);
 
     Vmm_.Init(Tlb_, Mmu_);
+
+    // Register initial Virtual Memory Areas (VMAs) so the VMM is aware of them.
+    // These areas were set up by the bootloader but are invisible to the generic VMM until
+    // registered.
+    // {
+    //     // Kernel Image
+    //     size_t kernel_size =
+    //         reinterpret_cast<uptr>(args.kernel_end) - reinterpret_cast<uptr>(args.kernel_start);
+    //
+    //     VMemArea kernel_vma{
+    //         .start                = args.kernel_start,
+    //         .size                 = kernel_size,
+    //         .flags                = {.readable = true, .writable = true, .executable = true},
+    //         .type                 = VirtualMemAreaT::Anonymous,
+    //         .direct_mapping_start = VirtToPhys(args.kernel_start),
+    //         .next                 = nullptr
+    //     };
+
+    //     TRACE_INFO_MEMORY("Adding VMemArea for kernel");
+    //     if (auto res = Vmm_.AddArea(&KernelAddressSpace_, kernel_vma); !res) {
+    //         TRACE_WARN_MEMORY("Failed to register Kernel VMA");
+    //     }
+
+    //     // Direct Physical Map
+    //     VMemArea dm_vma{
+    //         .start                = UptrToPtr<void>(hal::kDirectMapAddrStart),
+    //         .size                 = hal::kDirectMemMapSizeGb * 1024ULL * 1024ULL * 1024ULL,
+    //         .flags                = {.readable = true, .writable = true, .executable = false},
+    //         .type                 = VirtualMemAreaT::DirectMapping,
+    //         .direct_mapping_start = UptrToPtr<void>(0),
+    //         .next                 = nullptr
+    //     };
+
+    //     TRACE_INFO_MEMORY("Adding VMemArea for direct mem mapping");
+    //     if (auto res = Vmm_.AddArea(&KernelAddressSpace_, dm_vma); !res) {
+    //         TRACE_WARN_MEMORY("Failed to register Direct Map VMA");
+    //     }
+    // }
 }
 
 void internal::MemoryModule::RegisterPageFault(HardwareModule &hw)

--- a/kernel/src/modules/memory.cpp
+++ b/kernel/src/modules/memory.cpp
@@ -28,7 +28,7 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
     // Prune whatever bootloader had left over
     TRACE_INFO_MEMORY("Unmapping lower half of memory");
     {
-        // Mmu_.UnmapLowerHalf(args.root_page_table, PageMetaTable_, BitmapPmm_, Tlb_);
+        Mmu_.UnmapLowerHalf(args.root_page_table, PageMetaTable_, BitmapPmm_, Tlb_);
     }
 
     constexpr size_t kInitialBuddyPagesLimit = 4096;  // 16MB

--- a/kernel/src/modules/memory.cpp
+++ b/kernel/src/modules/memory.cpp
@@ -8,9 +8,6 @@
 #include "mem/virt/page_fault.hpp"
 #include "trace_framework.hpp"
 
-// TMP
-#include "drivers/serial/qemu.hpp"
-
 using namespace Mem;
 
 internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept

--- a/kernel/src/modules/memory.cpp
+++ b/kernel/src/modules/memory.cpp
@@ -8,12 +8,16 @@
 #include "mem/virt/page_fault.hpp"
 #include "trace_framework.hpp"
 
+// TMP
+#include "drivers/serial/qemu.hpp"
+
 using namespace Mem;
 
 internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
     : KernelAddressSpace_(args.root_page_table)
 {
     DEBUG_INFO_MEMORY("MemoryModule::MemoryModule()");
+    trace::Flush();
 
     // Prepare
     const size_t total_pages    = args.total_page_frames;
@@ -21,14 +25,21 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
     data_structures::BitMapView bmv{mem_bitmap, total_pages};
 
     // Init
+    TRACE_INFO_MEMORY("Bitmap");
+    trace::Flush();
     BitmapPmm_.Init(bmv);
 
+    TRACE_INFO_MEMORY("Pmt");
+    trace::Flush();
     PageMetaTable_.Init(args.total_page_frames, BitmapPmm_);
 
     // Prune whatever bootloader had left over
     TRACE_INFO_MEMORY("Unmapping lower half of memory");
+    trace::Flush();
     {
-        // Mmu_.UnmapLowerHalf(args.root_page_table, PageMetaTable_, BitmapPmm_, Tlb_);
+        QemuTerminalWriteString("test1\n");
+        Mmu_.UnmapLowerHalf(args.root_page_table, PageMetaTable_, BitmapPmm_, Tlb_);
+        QemuTerminalWriteString("test2\n");
     }
 
     constexpr size_t kInitialBuddyPagesLimit = 4096;  // 16MB
@@ -36,17 +47,27 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
     // This limit is for speed of boot. This operation should have
     // a follow up once kernel is booted, and we have another CPU, we
     // could offload this operation to.
+    QemuTerminalWriteString("test3.1\n");
+    TRACE_INFO_MEMORY("Buddy Init");
+    QemuTerminalWriteString("test3.2\n");
+    trace::Flush();
     BuddyPmm_.Init(BitmapPmm_, PageMetaTable_, kInitialBuddyPagesLimit);
+    TRACE_INFO_MEMORY("Buddy End");
+    QemuTerminalWriteString("test4\n");
+    trace::Flush();
 
     TRACE_INFO_MEMORY("Reconstructing page table metadata from root: 0x%p", args.root_page_table);
+    trace::Flush();
     // Mmu_.ReconstructAddressSpace(args.root_page_table, PageMetaTable_);
 
     SlabAllocator_.Init(BuddyPmm_);
+    QemuTerminalWriteString("test5\n");
 
     Heap_.Init(PageMetaTable_, BuddyPmm_, SlabAllocator_);
 
     Vmm_.Init(Tlb_, Mmu_);
 
+    // TODO: This makes kernel stuck in infninite loop? Shoudnt?
     // Register initial Virtual Memory Areas (VMAs) so the VMM is aware of them.
     // These areas were set up by the bootloader but are invisible to the generic VMM until
     // registered.

--- a/kernel/src/modules/memory.cpp
+++ b/kernel/src/modules/memory.cpp
@@ -39,7 +39,7 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
     BuddyPmm_.Init(BitmapPmm_, PageMetaTable_, kInitialBuddyPagesLimit);
 
     TRACE_INFO_MEMORY("Reconstructing page table metadata from root: 0x%p", args.root_page_table);
-    // Mmu_.ReconstructAddressSpace(args.root_page_table, PageMetaTable_);
+    Mmu_.ReconstructAddressSpace(args.root_page_table, PageMetaTable_);
 
     SlabAllocator_.Init(BuddyPmm_);
 


### PR DESCRIPTION
## Problem
Since leaving bootloader, there were still some issues and inconsistencies with the state of AlkOS kernel.
Namely: 
- The first 10gb of mem were still identity mapped by the bootloader (a legacy mapping)
- The kernel was mapped into the vmem, but the virtual memory manager wasn't AWARE that the kernel itself is mapped.
- The hardware (page tables) and software (bookkeeping info) were desynced

## Solution
This PR:
- Tears down all memory mappings below the higher half
- Implements bookkeeping that allows to effectively unmap pages
- Synchronizes hardware with the bookkeeping structures
- Fixes all legacy direct uses of physical ptrs

## Bugs
Tearing down the identity mapping exposed a BUG which behaved this way:
- The MSR GsBase register is set up to point to a valid address
- After flushing a new GDT, the MSR GsBase is set to 0x0 as a side effect
- The GsBase is not adjusted, so it points to 0x0
- 0x0 is a valid address under the legacy mapping. Code reads garbage
- After tearing down the legacy mapping it stops working
- This means the trace framework itself is paralyzed and doesn't work
- Nothing is reported or logged. Just random crash SOMEWHERE.
This is fixed. :DD and it took me a long time.