### PR TITLE
Kryczkal/vmm set vma flags

### DIFF
--- a/kernel/arch/x86_64/src/cpu/enable_nxe.nasm
+++ b/kernel/arch/x86_64/src/cpu/enable_nxe.nasm
@@ -1,0 +1,47 @@
+    bits 64
+
+    %include "startup/panic.nasm"
+
+    ; Extended Feature Enable Register (EFER)
+    EFER_MSR        equ 0xC0000080
+    EFER_NXE_BIT    equ 1 << 11
+
+    ; CPUID Extended Processor Info
+    CPUID_EXT_FUNC  equ 0x80000001
+    CPUID_NX_BIT    equ 1 << 20    ; In EDX
+
+    section .rodata
+    FAIL_NX         db "CPU does not support No-Execute (NX) bit. Halting.", 0
+
+    section .text
+    global EnableNXE
+
+EnableNXE:
+    push rbx
+    push rcx
+    push rdx
+
+    ; Check if CPU supports NX (CPUID 0x80000001, Bit 20 of EDX)
+    mov eax, 0x80000000
+    cpuid
+    cmp eax, CPUID_EXT_FUNC
+    jb .no_nx_support       ; Extended functions not supported
+
+    mov eax, CPUID_EXT_FUNC
+    cpuid
+    test edx, CPUID_NX_BIT
+    jz .no_nx_support
+
+    ; Enable NXE in EFER MSR
+    mov ecx, EFER_MSR
+    rdmsr                   ; Read EFER into EDX:EAX
+    bts eax, 11             ; Set bit 11 (NXE)
+    wrmsr                   ; Write EFER back
+
+    pop rdx
+    pop rcx
+    pop rbx
+    ret
+
+.no_nx_support:
+    panic FAIL_NX

--- a/kernel/arch/x86_64/src/hal/impl/mmu.cpp
+++ b/kernel/arch/x86_64/src/hal/impl/mmu.cpp
@@ -324,6 +324,29 @@ expected<PPtr<void>, MemError> Mmu::Translate(VPtr<AddressSpace> as, VPtr<void> 
     return pme_l1->GetFrameAddress();
 }
 
+expected<void, MemError> Mmu::SetPageFlags(VPtr<AddressSpace> as, VPtr<void> vaddr, PageFlags flags)
+{
+    auto res = WalkToEntry<1>(as, vaddr, false);
+    if (!res) {
+        return unexpected(MemError::NotFound);
+    }
+
+    auto *pme_l1 = *res;
+    if (!pme_l1->IsPresent()) {
+        return unexpected(MemError::NotFound);
+    }
+
+    // Preserve address, update flags
+    auto paddr = pme_l1->GetFrameAddress();
+
+    // We need to clear the entry before setting it again to avoid ORing flags
+    *reinterpret_cast<u64 *>(pme_l1) = 0;
+
+    pme_l1->SetFrameAddress(paddr, ToArchFlags(flags));
+
+    return {};
+}
+
 void Mmu::ReconstructAddressSpace(Mem::PPtr<void> root_page_table, Mem::PageMetaTable &pmt)
 {
     ReconstructRecursive<4>(root_page_table, nullptr, pmt);

--- a/kernel/arch/x86_64/src/hal/impl/mmu.cpp
+++ b/kernel/arch/x86_64/src/hal/impl/mmu.cpp
@@ -141,12 +141,14 @@ expected<Mem::VPtr<PageMapEntry<kLevel>>, Mem::MemError> Mmu::WalkToEntry(
     static_assert(kLevel > 0);
     static_assert(kLevel <= 4);
 
-    static constexpr u64 kDefFlags = kPresentBit | kWriteBit | kUserAccessibleBit;
+    // static constexpr u64 kDefFlags = kPresentBit | kWriteBit | kUserAccessibleBit;
 
     // Helper lambda to process each level
     auto ProcessLevel = [&]<size_t L>(
                             Mem::VPtr<PageMapEntry<L>> pme, bool create
                         ) -> expected<Mem::VPtr<PageMapEntry<L - 1>>, Mem::MemError> {
+        constexpr u64 kDefFlags = kPresentBit | kWriteBit | kUserAccessibleBit;
+
         if (pme->IsPresent()) {
             return reinterpret_cast<PageMapEntry<L - 1> *>(
                 Mem::PhysToVirt(pme->GetNextLevelTable())
@@ -357,7 +359,6 @@ void Mmu::UnmapLowerHalf(
 )
 {
     auto *pml4_virt = reinterpret_cast<PageMapTable<4> *>(PhysToVirt(root_page_table));
-    auto &pml4_meta = GetPageMeta(root_page_table, pmt);
 
     constexpr size_t kLowerHalfLimit = 256;
     for (size_t i = 0; i < kLowerHalfLimit; ++i) {

--- a/kernel/arch/x86_64/src/hal/impl/mmu.cpp
+++ b/kernel/arch/x86_64/src/hal/impl/mmu.cpp
@@ -263,7 +263,7 @@ expected<void, MemError> Mmu::UnMap(VPtr<AddressSpace> as, VPtr<void> vaddr)
     }
 
     // 2. Clear Entry
-    pme_l1->SetFrameAddress(0, 0);
+    *reinterpret_cast<u64 *>(pme_l1) = 0;
 
     // 3. Update RefCount
     auto *l1_table_virt = AlignDown(pme_l1, hal::kPageSizeBytes);
@@ -339,12 +339,15 @@ expected<void, MemError> Mmu::SetPageFlags(VPtr<AddressSpace> as, VPtr<void> vad
     }
 
     // Preserve address, update flags
-    auto paddr = pme_l1->GetFrameAddress();
+    auto *paddr = pme_l1->GetFrameAddress();
 
     // We need to clear the entry before setting it again to avoid ORing flags
     *reinterpret_cast<u64 *>(pme_l1) = 0;
 
     pme_l1->SetFrameAddress(paddr, ToArchFlags(flags));
+
+    // Flush TLB for this page immediately to ensure CPU sees new permissions
+    MemoryModule::Get().GetTlb().InvalidatePage(vaddr);
 
     return {};
 }

--- a/kernel/arch/x86_64/src/hal/impl/mmu.hpp
+++ b/kernel/arch/x86_64/src/hal/impl/mmu.hpp
@@ -40,6 +40,10 @@ class Mmu : public MmuAPI
         Mem::PPtr<void> root_page_table, Mem::PageMetaTable &pmt, Mem::BitmapPmm &pmm, hal::Tlb &tlb
     );
 
+    expected<void, Mem::MemError> SetPageFlags(
+        Mem::VPtr<Mem::AddressSpace> as, Mem::VPtr<void> vaddr, PageFlags flags
+    );
+
     private:
     template <size_t kLevel>
     u64 PmeIdx(Mem::VPtr<void> vaddr);

--- a/kernel/arch/x86_64/src/interrupts/idt.nasm
+++ b/kernel/arch/x86_64/src/interrupts/idt.nasm
@@ -38,6 +38,7 @@ isr_wrapper_%+%1:
     add rsp, _shadow_space      ; Deallocate shadow space.
     pop_all_regs                    ; Restore registers.
     add rsp, _all_reg_size          ; Deallocate register save space.
+    add rsp, 8                      ; Pop error code.
     iretq
 %endmacro
 

--- a/kernel/arch/x86_64/src/kernel/init.cpp
+++ b/kernel/arch/x86_64/src/kernel/init.cpp
@@ -33,6 +33,7 @@ BEGIN_DECL_C
 void EnableOSXSave();
 void EnableSSE();
 void EnableAVX();
+void EnableNXE();
 
 END_DECL_C
 
@@ -63,6 +64,7 @@ void ArchInit(const RawBootArguments &)
     EnableOSXSave();
     EnableSSE();
     EnableAVX();
+    EnableNXE();
 
     HardwareModule::Init();
     HardwareModule::Get().GetInterrupts().FirstStageInit();

--- a/kernel/arch/x86_64/src/mem/page_map.hpp
+++ b/kernel/arch/x86_64/src/mem/page_map.hpp
@@ -181,7 +181,8 @@ struct PageMapEntry<3, kHugePage> {
 
     void SetFrameAddress(Mem::PPtr<void> page_addr, u64 flags)
     {
-        frame = Mem::PtrToUptr(page_addr) >> 30;
+        *reinterpret_cast<u64 *>(this) = 0;
+        frame                          = Mem::PtrToUptr(page_addr) >> 30;
         *reinterpret_cast<u64 *>(this) |= flags | kHugePageBit;
     }
 } PACK;
@@ -259,7 +260,8 @@ struct PageMapEntry<2, kHugePage> {
 
     void SetFrameAddress(Mem::PPtr<void> page_addr, u64 flags)
     {
-        frame = Mem::PtrToUptr(page_addr) >> 21;
+        *reinterpret_cast<u64 *>(this) = 0;
+        frame                          = Mem::PtrToUptr(page_addr) >> 21;
         *reinterpret_cast<u64 *>(this) |= flags | kHugePageBit;
     }
 } PACK;
@@ -300,7 +302,8 @@ struct PageMapEntry<1> {
 
     void SetFrameAddress(Mem::PPtr<void> page_addr, u64 flags)
     {
-        frame = Mem::PtrToUptr(page_addr) >> 12;
+        *reinterpret_cast<u64 *>(this) = 0;
+        frame                          = Mem::PtrToUptr(page_addr) >> 12;
         *reinterpret_cast<u64 *>(this) |= flags;
     }
 } PACK;

--- a/kernel/src/hal/api/mmu.hpp
+++ b/kernel/src/hal/api/mmu.hpp
@@ -115,6 +115,17 @@ struct MmuAPI {
     void UnmapLowerHalf(
         Mem::PPtr<void> root_page_table, Mem::PageMetaTable &pmt, Mem::BitmapPmm &pmm, hal::Tlb &tlb
     );
+
+    /**
+     * @brief Updates the flags of an existing mapping.
+     * @param as The address space.
+     * @param vaddr The virtual address.
+     * @param flags The new flags.
+     * @return Success, or NotFound if page is not mapped.
+     */
+    expected<void, Mem::MemError> SetPageFlags(
+        Mem::VPtr<Mem::AddressSpace> as, Mem::VPtr<void> vaddr, PageFlags flags
+    );
 };
 
 }  // namespace arch

--- a/kernel/src/mem/virt/page_fault.cpp
+++ b/kernel/src/mem/virt/page_fault.cpp
@@ -11,13 +11,18 @@ namespace Mem
 
 void PageFaultHandler(intr::LitExcEntry &, hal::ExceptionData *data)
 {
-    TRACE_INFO_GENERAL("PageFaultHandler: Enter");
+    TRACE_INFO_GENERAL("PageFaultHandler()");
     using namespace hal;
     ASSERT_NOT_NULL(data);
 
     PageFaultData pfd = ParsePageFaultData(*data);
     const auto &f_ptr = pfd.faulting_ptr;
     const auto &err   = pfd.error;
+
+    TRACE_INFO_GENERAL(
+        "PageFaultHandler: Addr=%p, P=%d, W=%d, U=%d, R=%d, I=%d", f_ptr, err.present, err.write,
+        err.user, err.reserved_bits, err.instruction_fetch
+    );
 
     auto &as           = MemoryModule::Get().GetKernelAddressSpace();
     auto area_or_error = as.FindArea(f_ptr);
@@ -66,7 +71,7 @@ void PageFaultHandler(intr::LitExcEntry &, hal::ExceptionData *data)
         hal::PageFlags page_flags{
             .Present        = true,
             .Writable       = vma.flags.writable,
-            .UserAccessible = false,
+            .UserAccessible = true,
             .WriteThrough   = false,
             .CacheDisable   = false,
             .Global         = false,

--- a/kernel/src/mem/virt/vmm.cpp
+++ b/kernel/src/mem/virt/vmm.cpp
@@ -74,4 +74,43 @@ expected<void, MemError> Vmm::RmArea(VPtr<AddrSp> as, VPtr<void> region_start)
     return {};
 }
 
+expected<void, MemError> Vmm::UpdateAreaFlags(
+    VPtr<AddressSpace> as, VPtr<void> region_start, VirtualMemAreaFlags vmaf
+)
+{
+    auto a_or_err = as->FindArea(region_start);
+    UNEXPECTED_RET_IF_ERR(a_or_err);
+    auto *area = *a_or_err;
+    if (area->start != region_start) {
+        return unexpected(MemError::InvalidArgument);
+    }
+
+    area->flags = vmaf;
+    hal::PageFlags pf{
+        .Present        = true,
+        .Writable       = vmaf.writable,
+        .UserAccessible = true,  // User space VMA
+        .WriteThrough   = false,
+        .CacheDisable   = false,
+        .Global         = false,
+        .NoExecute      = !vmaf.executable
+    };
+
+    uptr start = PtrToUptr(area->start);
+    uptr end   = start + area->size;
+
+    for (uptr v = start; v < end; v += hal::kPageSizeBytes) {
+        auto res = mmu_->SetPageFlags(as, UptrToPtr<void>(v), pf);
+        if (res) {
+            tlb_->InvalidatePage(UptrToPtr<void>(v));
+        } else if (res.error() != MemError::NotFound) {
+            return unexpected(res.error());
+        }
+        // NotFound means page not mapped yet (lazy allocation),
+        // which is fine as future faults will use new VMA flags.
+    }
+
+    return {};
+}
+
 }  // namespace Mem

--- a/kernel/src/mem/virt/vmm.hpp
+++ b/kernel/src/mem/virt/vmm.hpp
@@ -40,9 +40,9 @@ class VirtualMemoryManager
 
     expected<VPtr<void>, MemError> AddArea(VPtr<AddressSpace> as, VMemArea vma);
     expected<void, MemError> RmArea(VPtr<AddressSpace> as, VPtr<void> region_start);
-    // expected<void, MemError> UpdateAreaFlags(
-    //     VPtr<AddressSpace> as, VPtr<void> region_start, VirtualMemAreaFlags vmaf
-    // );
+    expected<void, MemError> UpdateAreaFlags(
+        VPtr<AddressSpace> as, VPtr<void> region_start, VirtualMemAreaFlags vmaf
+    );
 
     private:
     // ------------------------------

--- a/kernel/src/sys/loader.cpp
+++ b/kernel/src/sys/loader.cpp
@@ -95,16 +95,19 @@ expected<Mem::VPtr<void>, LoadError> ElfLoader::Load(const vfs::Path &path, Mem:
         u64 size       = virt_end - virt_start;
 
         // Permissions
-        VirtualMemAreaFlags flags = {};
-        flags.readable            = (ph.flags & Elf::ProgramHeader::kFlagRead) != 0U;
-        flags.writable            = (ph.flags & Elf::ProgramHeader::kFlagWrite) != 0U;
-        flags.executable          = (ph.flags & Elf::ProgramHeader::kFlagExec) != 0U;
+        VirtualMemAreaFlags original_flags = {};
+        original_flags.readable            = (ph.flags & Elf::ProgramHeader::kFlagRead) != 0U;
+        original_flags.writable            = (ph.flags & Elf::ProgramHeader::kFlagWrite) != 0U;
+        original_flags.executable          = (ph.flags & Elf::ProgramHeader::kFlagExec) != 0U;
+
+        VirtualMemAreaFlags loading_flags = original_flags;
+        loading_flags.writable            = true;
 
         // Add VMA to Address Space
         VMemArea vma{
             .start                = UptrToPtr<void>(virt_start),
             .size                 = size,
-            .flags                = flags,
+            .flags                = loading_flags,
             .type                 = VirtualMemAreaT::Anonymous,
             .direct_mapping_start = nullptr,
         };
@@ -130,6 +133,16 @@ expected<Mem::VPtr<void>, LoadError> ElfLoader::Load(const vfs::Path &path, Mem:
         if (ph.memsz > ph.filesz) {
             void *bss_dest = reinterpret_cast<void *>(ph.vaddr + ph.filesz);
             memset(bss_dest, 0, ph.memsz - ph.filesz);
+        }
+
+        // Restore flags
+        if (loading_flags.writable != original_flags.writable) {
+            if (auto res =
+                    MemoryModule::Get().GetVmm().UpdateAreaFlags(&as, vma.start, original_flags);
+                !res) {
+                TRACE_WARN_GENERAL("Failed to restore flags for segment %d", i);
+                return unexpected(LoadError::MemoryError);
+            }
         }
 
         TRACE_INFO_GENERAL("Loaded segment %d: [0x%llX - 0x%llX]", i, virt_start, virt_end);

--- a/kernel/src/sys/loader.cpp
+++ b/kernel/src/sys/loader.cpp
@@ -8,6 +8,7 @@
 #include "modules/memory.hpp"
 #include "modules/vfs.hpp"
 #include "sys/elf/elf.hpp"
+
 #include "trace_framework.hpp"
 
 namespace System
@@ -40,9 +41,11 @@ bool ValidateElfHeader(const Elf::Header &header)
 
 expected<Mem::VPtr<void>, LoadError> ElfLoader::Load(const vfs::Path &path, Mem::AddressSpace &as)
 {
+    TRACE_INFO_GENERAL("ElfLoader::Load()");
     auto &vfs = VfsModule::Get();
 
     // 1. Check if file exists
+    TRACE_FREQ_INFO_GENERAL("Validating the file exists");
     auto exists_res = vfs.FileExists(path);
     if (!exists_res.has_value() || !exists_res.value()) {
         return unexpected(LoadError::FileNotFound);
@@ -56,6 +59,7 @@ expected<Mem::VPtr<void>, LoadError> ElfLoader::Load(const vfs::Path &path, Mem:
     }
 
     // 3. Validate ELF
+    TRACE_FREQ_INFO_GENERAL("Validating the ELF header");
     if (!ValidateElfHeader(header)) {
         return unexpected(LoadError::InvalidElf);
     }
@@ -73,6 +77,7 @@ expected<Mem::VPtr<void>, LoadError> ElfLoader::Load(const vfs::Path &path, Mem:
         Mem::KFree(ph_raw);
     });
 
+    TRACE_FREQ_INFO_GENERAL("Validating the ELF header");
     read_res = vfs.ReadFile(path, ph_raw, ph_size, header.phoff);
     if (!read_res.has_value() || read_res.value() != ph_size) {
         return unexpected(LoadError::IoError);
@@ -81,6 +86,7 @@ expected<Mem::VPtr<void>, LoadError> ElfLoader::Load(const vfs::Path &path, Mem:
     auto *ph_table = reinterpret_cast<Elf::ProgramHeader *>(ph_raw);
 
     // 5. Load Segments
+    TRACE_FREQ_INFO_GENERAL("Validating the ELF header");
     for (u16 i = 0; i < header.phnum; ++i) {
         auto &ph = ph_table[i];
         if (ph.type != Elf::ProgramHeader::kTypeLoad) {
@@ -93,6 +99,7 @@ expected<Mem::VPtr<void>, LoadError> ElfLoader::Load(const vfs::Path &path, Mem:
         u64 virt_start = AlignDown(ph.vaddr, hal::kPageSizeBytes);
         u64 virt_end   = AlignUp(ph.vaddr + ph.memsz, hal::kPageSizeBytes);
         u64 size       = virt_end - virt_start;
+        TRACE_INFO_GENERAL("Loading segment %d: [0x%llX - 0x%llX]", i, virt_start, virt_end);
 
         // Permissions
         VirtualMemAreaFlags original_flags = {};
@@ -144,8 +151,6 @@ expected<Mem::VPtr<void>, LoadError> ElfLoader::Load(const vfs::Path &path, Mem:
                 return unexpected(LoadError::MemoryError);
             }
         }
-
-        TRACE_INFO_GENERAL("Loaded segment %d: [0x%llX - 0x%llX]", i, virt_start, virt_end);
     }
 
     u64 entry_point = header.entry;


### PR DESCRIPTION
## Problem:
Page flags need to enable writing during loading an elf, but need to be set to 
read only after it is loaded.

## Solution
Added mechanizm to update the flags of a vmemarea
Also fixed various bugs
most noticalbly - stack misalignment after return from error idt.