### PR TITLE
Kryczkal/fix vmm refactor 02

### DIFF
--- a/kernel/arch/x86_64/src/hal/impl/mmu.hpp
+++ b/kernel/arch/x86_64/src/hal/impl/mmu.hpp
@@ -24,6 +24,9 @@ class Mmu : public MmuAPI
     void Unmap(Context &ctx, Mem::PPtr<void> root, Mem::VPtr<void> vaddr);
 
     template <MmuContext Context>
+    void ClearUserMappings(Context &ctx, Mem::PPtr<void> root);
+
+    template <MmuContext Context>
     expected<Mem::PPtr<void>, Mem::MemError> Translate(
         Context &ctx, Mem::PPtr<void> root, Mem::VPtr<void> vaddr
     );

--- a/kernel/arch/x86_64/src/hal/impl/mmu.tpp
+++ b/kernel/arch/x86_64/src/hal/impl/mmu.tpp
@@ -158,6 +158,25 @@ void Mmu::Unmap(Context &ctx, Mem::PPtr<void> root, Mem::VPtr<void> vaddr)
 }
 
 template <MmuContext Context>
+void Mmu::ClearUserMappings(Context &ctx, Mem::PPtr<void> root)
+{
+    // On x86_64, the lower half of the address space corresponds to
+    // the first 256 entries of PML4.
+    constexpr size_t kLowerHalfEntries = 256;
+
+    auto *pml4 = reinterpret_cast<PageMapTable<4> *>(Mem::PhysToVirt(root));
+
+    for (size_t i = 0; i < kLowerHalfEntries; ++i) {
+        auto &entry = (*pml4)[i];
+        if (entry.IsPresent()) {
+            // Recursively destroy the sub-tables
+            DestroyTable(ctx, reinterpret_cast<Mem::PPtr<void>>(entry.GetNextLevelTable()), 3);
+            entry.Clear();
+        }
+    }
+}
+
+template <MmuContext Context>
 expected<Mem::PPtr<void>, Mem::MemError> Mmu::Translate(
     Context &, Mem::PPtr<void> root, Mem::VPtr<void> vaddr
 )
@@ -190,14 +209,24 @@ expected<Mem::PPtr<void>, Mem::MemError> Mmu::Translate(
 template <TableVisitor Visitor>
 void Mmu::VisitTables(Mem::PPtr<void> root, Visitor visitor)
 {
-    // Visitor signature: void(Mem::PPtr<void> table, uint8_t level)
+    // Visitor signature: void(Mem::PPtr<void> table, uint8_t level, size_t entry_count)
 
     // We traverse recursively
     auto RecVisit = [&]<size_t Level>(this auto &&self, Mem::PPtr<void> table_phys) -> void {
-        visitor(table_phys, Level);
+        auto *table = reinterpret_cast<PageMapTable<Level> *>(Mem::PhysToVirt(table_phys));
+
+        // First pass: count entries
+        size_t count = 0;
+        for (const auto &entry : *table) {
+            if (entry.IsPresent()) {
+                count++;
+            }
+        }
+
+        // Invoke visitor with stats
+        visitor(table_phys, Level, count);
 
         if constexpr (Level > 1) {
-            auto *table = reinterpret_cast<PageMapTable<Level> *>(Mem::PhysToVirt(table_phys));
             for (const auto &entry : *table) {
                 if (entry.IsPresent() && !entry.IsHuge()) {
                     self.template operator()<Level - 1>(

--- a/kernel/src/hal/api/mmu.hpp
+++ b/kernel/src/hal/api/mmu.hpp
@@ -66,10 +66,11 @@ concept MmuContext = requires(T ctx, u8 level, Mem::PPtr<void> table) {
 
 /**
  * @brief Concept for a visitor function used to traverse page tables.
+ * Visitor signature: void(Mem::PPtr<void> table, u8 level, size_t entry_count)
  */
 template <typename Func>
-concept TableVisitor = requires(Func f, Mem::PPtr<void> table, u8 level) {
-    { f(table, level) } -> std::same_as<void>;
+concept TableVisitor = requires(Func f, Mem::PPtr<void> table, u8 level, size_t count) {
+    { f(table, level, count) } -> std::same_as<void>;
 };
 
 struct MmuAPI {
@@ -99,6 +100,15 @@ struct MmuAPI {
     void Unmap(Context &ctx, Mem::PPtr<void> root, Mem::VPtr<void> vaddr);
 
     /**
+     * @brief Clears the user-space portion of the virtual address space.
+     *
+     * This destroys all page tables associated with the lower half (user space)
+     * of the address space, freeing them via the provided context.
+     */
+    template <MmuContext Context>
+    void ClearUserMappings(Context &ctx, Mem::PPtr<void> root);
+
+    /**
      * @brief Updates flags for an existing mapping.
      */
     expected<void, Mem::MemError> SetPageFlags(
@@ -121,8 +131,11 @@ struct MmuAPI {
     void SwitchRoot(Mem::PPtr<void> root);
 
     /**
-     * @brief Walks the page table hierarchy and calls the visitor for each present table.
-     * Useful for reconstructing metadata or debugging.
+     * @brief Walks the page table hierarchy.
+     *
+     * Calls the visitor for each present table in the hierarchy.
+     * The visitor receives the table address, its level, and the number of active entries
+     * within that table (useful for reconstructing reference counts).
      */
     template <TableVisitor Visitor>
     void VisitTables(Mem::PPtr<void> root, Visitor visitor);

--- a/kernel/src/hal/mmu.hpp
+++ b/kernel/src/hal/mmu.hpp
@@ -36,8 +36,6 @@ struct KernelMmuContext {
         memset(Mem::PhysToVirt(ptr), 0, hal::kPageSizeBytes);
 
         auto &meta = pmt.GetPageMeta(ptr);
-        // Parent tracking is not strictly enforced by this context during alloc,
-        // but we init the metadata type.
         meta.InitPageTable(level);
         return reinterpret_cast<Mem::PPtr<void>>(ptr);
     }
@@ -46,7 +44,7 @@ struct KernelMmuContext {
     {
         (void)level;
         auto &meta = pmt.GetPageMeta(table);
-        meta.InitAllocated(0);  // Reset type to generic allocated before freeing
+        meta.InitAllocated(0);
         pmm.Free(reinterpret_cast<Mem::PPtr<Mem::Page>>(table));
     }
 
@@ -64,35 +62,6 @@ struct KernelMmuContext {
             pt.ref_count--;
         return pt.ref_count == 0;
     }
-};
-
-/**
- * @brief Boot MMU Context using BitmapPmm (before Buddy is ready).
- * Used for cleaning up bootloader tables.
- */
-struct BootstrapMmuContext {
-    Mem::BitmapPmm &pmm;
-    Mem::PageMetaTable &pmt;
-
-    expected<Mem::PPtr<void>, Mem::MemError> AllocateTable(uint8_t)
-    {
-        // Not implemented/Needed for cleanup
-        return unexpected(Mem::MemError::OutOfMemory);
-    }
-
-    void FreeTable(Mem::PPtr<void> table, uint8_t level)
-    {
-        (void)level;
-        auto &meta = pmt.GetPageMeta(table);
-        meta.InitAllocated(0);
-        pmm.Free(reinterpret_cast<Mem::PPtr<Mem::Page>>(table));
-    }
-
-    void IncreaseUsage(Mem::PPtr<void>) {}
-    bool DecreaseUsage(Mem::PPtr<void>)
-    {
-        return true;
-    }  // Always assume empty/freeable during force cleanup
 };
 
 class Mmu : public arch::Mmu
@@ -128,6 +97,13 @@ class Mmu : public arch::Mmu
         tlb_->InvalidatePage(vaddr);
     }
 
+    template <MmuContext Context>
+    void ClearUserMappings(Context &ctx, Mem::PPtr<void> root)
+    {
+        arch::Mmu::ClearUserMappings(ctx, root);
+        tlb_->FlushAll();
+    }
+
     expected<void, Mem::MemError> SetPageFlags(
         Mem::PPtr<void> root, Mem::VPtr<void> vaddr, PageFlags flags
     )
@@ -151,70 +127,6 @@ class Mmu : public arch::Mmu
         }
 
         tlb_->InvalidateRange(start, size);
-    }
-
-    /// Reconstructs metadata for an existing page table tree
-    void ReconstructAddressSpace(Mem::PPtr<void> root, Mem::PageMetaTable &pmt)
-    {
-        // Counts refs for a table by inspecting its entries
-        // Note: this assumes we are iterating a valid tree
-        // The Visitor in arch::Mmu doesn't provide entry counts, so we do it manually or
-        // rely on the fact that we can just set type for now.
-        // To strictly restore ref_counts, we need to count bits.
-
-        VisitTables(root, [&](Mem::PPtr<void> table, uint8_t level) {
-            auto &meta = pmt.GetPageMeta(table);
-            meta.InitPageTable(level);
-
-            // Count entries for ref_count
-            if (level > 1) {
-                u16 count = 0;
-                // Hack: we cast to generic array to count present bits
-                // This assumes standard x86 layout which HAL technically shouldn't know,
-                // but Mmu inherits from arch::Mmu so it can access Arch defs if included.
-                // We can't access PageMapTable<L> easily here without template.
-                // Let's rely on a simplified assumption or add a helper in Arch.
-                // For now, we set ref_count to 1 to prevent accidental freeing
-                // until we implement proper counting or let the system run.
-                // Ideally, we would iterate the table.
-                auto *virt = reinterpret_cast<u64 *>(Mem::PhysToVirt(table));
-                for (int i = 0; i < 512; ++i) {
-                    if (virt[i] & 1)
-                        count++;
-                }
-                Mem::PageMeta::AsPageTable(meta).ref_count = count;
-            } else {
-                // Level 1 (PT)
-                u16 count  = 0;
-                auto *virt = reinterpret_cast<u64 *>(Mem::PhysToVirt(table));
-                for (int i = 0; i < 512; ++i) {
-                    if (virt[i] & 1)
-                        count++;
-                }
-                Mem::PageMeta::AsPageTable(meta).ref_count = count;
-            }
-        });
-    }
-
-    void UnmapLowerHalf(Mem::PPtr<void> root, Mem::PageMetaTable &pmt, Mem::BitmapPmm &pmm)
-    {
-        BootstrapMmuContext ctx{pmm, pmt};
-
-        // Manual iteration of PML4 lower half
-        auto *pml4                         = reinterpret_cast<u64 *>(Mem::PhysToVirt(root));
-        constexpr size_t kLowerHalfEntries = 256;
-
-        for (size_t i = 0; i < kLowerHalfEntries; ++i) {
-            if (pml4[i] & 1) {  // Present
-                Mem::PPtr<void> child =
-                    reinterpret_cast<Mem::PPtr<void>>(pml4[i] & 0x000FFFFFFFFFF000);  // Mask flags
-                DestroyTable(ctx, child, 3);  // Child is Level 3 (PDPT)
-                pml4[i] = 0;
-            }
-        }
-
-        // TLB flush should be handled by caller or here
-        SwitchRoot(root);  // Reload CR3 flushes TLB
     }
 };
 

--- a/kernel/src/mem/init/boot_mmu.hpp
+++ b/kernel/src/mem/init/boot_mmu.hpp
@@ -1,0 +1,78 @@
+#ifndef KERNEL_SRC_MEM_INIT_BOOT_MMU_HPP_
+#define KERNEL_SRC_MEM_INIT_BOOT_MMU_HPP_
+
+#include <expected.hpp>
+#include "hal/mmu.hpp"
+#include "mem/page_meta_table.hpp"
+#include "mem/phys/mngr/bitmap.hpp"
+
+namespace Mem::Boot
+{
+
+/**
+ * @brief Boot MMU Context using BitmapPmm (before Buddy is ready).
+ * Used for cleaning up bootloader tables.
+ */
+struct BootstrapMmuContext {
+    Mem::BitmapPmm &pmm;
+    Mem::PageMetaTable &pmt;
+
+    std::expected<Mem::PPtr<void>, Mem::MemError> AllocateTable(uint8_t)
+    {
+        // Allocation is not supported during cleanup phase
+        return std::unexpected(Mem::MemError::OutOfMemory);
+    }
+
+    void FreeTable(Mem::PPtr<void> table, uint8_t level)
+    {
+        (void)level;
+        auto &meta = pmt.GetPageMeta(table);
+        meta.InitAllocated(0);
+        pmm.Free(reinterpret_cast<Mem::PPtr<Mem::Page>>(table));
+    }
+
+    void IncreaseUsage(Mem::PPtr<void>) {}
+    bool DecreaseUsage(Mem::PPtr<void>)
+    {
+        // Always assume empty/freeable during force cleanup
+        return true;
+    }
+};
+
+class BootMmuCleaner
+{
+    public:
+    /**
+     * @brief Clears the identity mappings (user/lower half) left by the bootloader.
+     * This ensures the kernel starts with a clean user-space address range.
+     */
+    void CleanIdentityMappings(
+        hal::Mmu &mmu, Mem::BitmapPmm &pmm, Mem::PageMetaTable &pmt, Mem::PPtr<void> root
+    )
+    {
+        BootstrapMmuContext ctx{pmm, pmt};
+        mmu.ClearUserMappings(ctx, root);
+    }
+
+    /**
+     * @brief Reconstructs metadata (PageMetaTable) for the existing kernel page tables.
+     * The bootloader creates the initial tables, but our memory manager needs
+     * to know about them (type: PageTable, ref_count, etc.) to manage them later.
+     */
+    void ReconstructMetadata(hal::Mmu &mmu, Mem::PageMetaTable &pmt, Mem::PPtr<void> root)
+    {
+        mmu.VisitTables(root, [&](Mem::PPtr<void> table, uint8_t level, size_t entry_count) {
+            auto &meta = pmt.GetPageMeta(table);
+            meta.InitPageTable(level);
+
+            // Set the reference count based on the number of present entries
+            // This prevents the kernel from prematurely freeing these tables.
+            // Note: We cast entry_count to u16, assuming it fits (max 512).
+            Mem::PageMeta::AsPageTable(meta).ref_count = static_cast<u16>(entry_count);
+        });
+    }
+};
+
+}  // namespace Mem::Boot
+
+#endif  // KERNEL_SRC_MEM_INIT_BOOT_MMU_HPP_

--- a/kernel/src/modules/memory.cpp
+++ b/kernel/src/modules/memory.cpp
@@ -2,6 +2,7 @@
 
 #include "boot_args.hpp"
 #include "hal/constants.hpp"
+#include "mem/init/boot_mmu.hpp"
 #include "mem/page_meta_table.hpp"
 #include "mem/phys/mngr/bitmap.hpp"
 #include "mem/types.hpp"
@@ -25,9 +26,14 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
 
     PageMetaTable_.Init(args.total_page_frames, BitmapPmm_);
 
+    Mmu_.Init(Tlb_);
+
+    // Cleanup bootloader mappings and reconstruct metadata for kernel mappings
+    Mem::Boot::BootMmuCleaner boot_cleaner;
+
     TRACE_INFO_MEMORY("Unmapping lower half of memory");
     Mmu_.Init(Tlb_);
-    Mmu_.UnmapLowerHalf(args.root_page_table, PageMetaTable_, BitmapPmm_);
+    boot_cleaner.CleanIdentityMappings(Mmu_, BitmapPmm_, PageMetaTable_, args.root_page_table);
 
     constexpr size_t kInitialBuddyPagesLimit = 4096;  // 16MB
     // Note: Initializing buddy with all pages is a slow operation.
@@ -38,7 +44,7 @@ internal::MemoryModule::MemoryModule(const BootArguments &args) noexcept
 
     // Reconstruct metadata for the existing page table hierarchy passed by the bootloader.
     TRACE_INFO_MEMORY("Reconstructing page table metadata from root: 0x%p", args.root_page_table);
-    Mmu_.ReconstructAddressSpace(args.root_page_table, PageMetaTable_);
+    boot_cleaner.ReconstructMetadata(Mmu_, PageMetaTable_, args.root_page_table);
 
     SlabAllocator_.Init(BuddyPmm_);
 

--- a/scripts/tests/runner.py
+++ b/scripts/tests/runner.py
@@ -42,7 +42,6 @@ TEST_RUNS: list[TestRun] = [
         [
             "SnprintfTest_BufferSizeHandling",  # Fails <- issue added on low prio
             "SnprintfTest_EdgeCases",  # Fails <- issue added on low prio
-            "PageFaultHandlerTest*DirectMappedMemory*",
         ]
     )
 ]


### PR DESCRIPTION
## Problem
The functions that restore the coherency of VMM after bootloader, were completely out of place.

## Solution
Refactored the code so it makes sense