### PR TITLE
Kryczkal/userspace stack

### DIFF
--- a/kernel/arch/x86_64/src/hal/impl/constants.hpp
+++ b/kernel/arch/x86_64/src/hal/impl/constants.hpp
@@ -21,6 +21,8 @@ static constexpr size_t kPageShift          = 12;
 static constexpr u32 kMaxCores              = 512;
 static constexpr u16 kElfMachineType        = 0x3E;
 
+static constexpr bool kStackGrowsDown = true;
+
 // ------------------------------
 // Enums
 // ------------------------------

--- a/kernel/src/constants.hpp
+++ b/kernel/src/constants.hpp
@@ -1,7 +1,7 @@
 #ifndef KERNEL_SRC_CONSTANTS_HPP_
 #define KERNEL_SRC_CONSTANTS_HPP_
 
-#include "types.hpp"
+#include <types.hpp>
 
 static constexpr u16 kMaxProcesses    = 4096;
 static constexpr u32 kMaxThreads      = kMaxProcesses * 2;
@@ -9,9 +9,17 @@ static constexpr u32 kStackSize       = 64 * 1024;  // TODO 8 meg
 static constexpr u32 kKernelStackSize = 64 * 1024;  // TODO 1 meg
 static constexpr u32 kStackAlignment  = 64;
 
-static constexpr u64 kUserSpaceStart   = 0x0;
-static constexpr u64 kUserSpaceEnd     = 0x00007FFFFFFFFFFF;
-static constexpr u64 kKernelSpaceStart = 0xFFFF800000000000;
-static constexpr u64 kKernelSpaceEnd   = 0xFFFFFFFFFFFFFFFF;
+static constexpr u64 kUserSpaceStart          = 0x0;
+static constexpr u64 kUserSpaceEndInclusive   = 0x00007FFFFFFFFFFF;
+static constexpr u64 kUserSpaceEndExclusive   = kUserSpaceEndInclusive + 1;
+static constexpr u64 kKernelSpaceStart        = 0xFFFF800000000000;
+static constexpr u64 kKernelSpaceEndInclusive = 0xFFFFFFFFFFFFFFFF;
+
+NODISCARD FAST_CALL bool IsKernelSpace(const u64 address) { return address >= kKernelSpaceStart; }
+
+NODISCARD FAST_CALL bool IsKernelSpace(const void *address)
+{
+    return IsKernelSpace(reinterpret_cast<u64>(address));
+}
 
 #endif  // KERNEL_SRC_CONSTANTS_HPP_

--- a/kernel/src/constants.hpp
+++ b/kernel/src/constants.hpp
@@ -9,4 +9,9 @@ static constexpr u32 kStackSize       = 64 * 1024;  // TODO 8 meg
 static constexpr u32 kKernelStackSize = 64 * 1024;  // TODO 1 meg
 static constexpr u32 kStackAlignment  = 64;
 
+static constexpr u64 kUserSpaceStart   = 0x0;
+static constexpr u64 kUserSpaceEnd     = 0x00007FFFFFFFFFFF;
+static constexpr u64 kKernelSpaceStart = 0xFFFF800000000000;
+static constexpr u64 kKernelSpaceEnd   = 0xFFFFFFFFFFFFFFFF;
+
 #endif  // KERNEL_SRC_CONSTANTS_HPP_

--- a/kernel/src/hal/constants.hpp
+++ b/kernel/src/hal/constants.hpp
@@ -21,18 +21,10 @@ static_assert(kMaxCores <= kBitMask16);  // Must fit in u16
 
 static constexpr u16 kElfMachineType = arch::kElfMachineType;
 
+static constexpr bool kStackGrowsDown = arch::kStackGrowsDown;
+
 using arch::HardwareClockId;
 using arch::HardwareEventClockId;
-
-NODISCARD FAST_CALL bool IsKernelSpace(const u64 address)
-{
-    return address >= kKernelVirtualAddressStart;
-}
-
-NODISCARD FAST_CALL bool IsKernelSpace(const void *address)
-{
-    return IsKernelSpace(reinterpret_cast<u64>(address));
-}
 
 }  // namespace hal
 

--- a/kernel/src/hal/constants.hpp
+++ b/kernel/src/hal/constants.hpp
@@ -7,7 +7,6 @@
 
 namespace hal
 {
-static constexpr u64 kKernelVirtualAddressStart = arch::kKernelVirtualAddressStart;
 
 static constexpr u64 kDirectMapAddrStart = arch::kDirectMapAddrStart;
 static constexpr u64 kDirectMemMapSizeGb = arch::kDirectMemMapSizeGb;

--- a/kernel/src/mem/types.hpp
+++ b/kernel/src/mem/types.hpp
@@ -4,6 +4,7 @@
 #include <expected.hpp>
 #include <type_traits.hpp>
 #include <types.hpp>
+#include "constants.hpp"
 #include "hal/constants.hpp"
 
 namespace Mem
@@ -37,7 +38,7 @@ PPtr<T> VirtToPhys(VPtr<T> virtAddr)
         return reinterpret_cast<PPtr<T>>(vaddr - hal::kDirectMapAddrStart);
     }
 
-    return reinterpret_cast<PPtr<T>>(vaddr - hal::kKernelVirtualAddressStart);
+    return reinterpret_cast<PPtr<T>>(vaddr - kKernelSpaceStart);
 }
 
 template <typename T>

--- a/kernel/src/mem/virt/addr_space.cpp
+++ b/kernel/src/mem/virt/addr_space.cpp
@@ -5,6 +5,7 @@
 
 #include <template/scope_guard.hpp>
 
+#include "constants.hpp"
 #include "hal/constants.hpp"
 #include "hal/mmu.hpp"
 
@@ -63,6 +64,9 @@ AS::~AddressSpace()
 expected<void, MemError> AS::AddArea(VMemArea *vma)
 {
     ASSERT_NOT_NULL(vma);
+    R_ASSERT_TRUE(IsAligned(vma->GetStart(), hal::kPageSizeBytes), "VMA start is not aligned");
+    R_ASSERT_TRUE(IsAligned(vma->GetSize(), hal::kPageSizeBytes), "VMA size is not aligned");
+
     std::lock_guard guard(area_list_lock_);
     template_lib::ScopeGuard vma_guard([&] {
         KDelete(vma);
@@ -134,7 +138,7 @@ expected<TlbHint, MemError> AS::UpdateAreaFlags(VPtr<void> ptr, VirtualMemAreaFl
     auto start = vma->GetStart();
     auto size  = vma->GetSize();
 
-    bool is_kernel = (PtrToUptr(start) >= hal::kKernelVirtualAddressStart);
+    bool is_kernel = IsKernelSpace(start);
 
     hal::PageFlags pf{
         .Present        = true,
@@ -192,15 +196,19 @@ expected<GapInfo, MemError> AS::FindGap(size_t size, VPtr<void> range_start, VPt
     uptr search_start = range_start ? PtrToUptr(range_start) : 0;
     uptr search_end   = range_end ? PtrToUptr(range_end) : UINTPTR_MAX;
 
-    // Sentinel value
+    search_start = AlignUp(search_start, hal::kPageSizeBytes);
+    search_end   = AlignDown(search_end, hal::kPageSizeBytes);
+
     uptr prev_end = search_start;
 
     for (auto *vma : area_list_) {
         uptr curr_start = PtrToUptr(vma->GetStart());
         uptr curr_end   = curr_start + vma->GetSize();
 
-        // Find gaps only in the range of interest
+        // Search only in the range of interest
         if (curr_end <= search_start) {
+            // Handle case where VMA overlaps the search_start boundary but ends after it
+            prev_end = std::max(prev_end, curr_end);
             continue;
         }
         if (curr_start >= search_end) {
@@ -208,8 +216,8 @@ expected<GapInfo, MemError> AS::FindGap(size_t size, VPtr<void> range_start, VPt
         }
 
         // Gap found
-        uptr gap_start = prev_end;
-        uptr gap_end   = curr_start;
+        uptr gap_start = AlignUp(prev_end, hal::kPageSizeBytes);
+        uptr gap_end   = AlignDown(curr_start, hal::kPageSizeBytes);
 
         if (gap_end > gap_start && (gap_end - gap_start) >= size) {
             return GapInfo{UptrToPtr<void>(gap_start), size};
@@ -218,9 +226,10 @@ expected<GapInfo, MemError> AS::FindGap(size_t size, VPtr<void> range_start, VPt
         prev_end = curr_end;
     }
 
-    // Final check: gap between last processed area and search_end
-    if (search_end > prev_end && (search_end - prev_end) >= size) {
-        return GapInfo{UptrToPtr<void>(prev_end), size};
+    uptr gap_start = AlignUp(prev_end, hal::kPageSizeBytes);
+
+    if (search_end > gap_start && (search_end - gap_start) >= size) {
+        return GapInfo{UptrToPtr<void>(gap_start), size};
     }
 
     return unexpected(MemError::NotFound);

--- a/kernel/src/mem/virt/addr_space.cpp
+++ b/kernel/src/mem/virt/addr_space.cpp
@@ -2,8 +2,12 @@
 
 #include <macros.hpp>
 #include <mutex.hpp>
+
+#include <template/scope_guard.hpp>
+
 #include "hal/constants.hpp"
 #include "hal/mmu.hpp"
+
 #include "mem/error.hpp"
 #include "mem/heap.hpp"
 #include "mem/mmu/contexts.hpp"
@@ -60,21 +64,27 @@ expected<void, MemError> AS::AddArea(VMemArea *vma)
 {
     ASSERT_NOT_NULL(vma);
     std::lock_guard guard(area_list_lock_);
+    template_lib::ScopeGuard vma_guard([&] {
+        KDelete(vma);
+    });
 
-    // Check for overlapping areas
     for (auto it = area_list_.begin(); it != area_list_.end(); ++it) {
-        if (AreasOverlap(*it, vma)) {
-            // We own vma, so we must delete it on failure
-            KDelete(vma);
-            return unexpected(MemError::InvalidArgument);
+        VMemArea *current = *it;
+        RET_UNEXPECTED_IF(AreasOverlap(current, vma), MemError::InvalidArgument);
+
+        if (vma->GetStart() < current->GetStart()) {
+            auto *pos = it.GetNode();
+            auto *new_node =
+                pos->prev ? area_list_.InsertAfter(pos->prev, vma) : area_list_.PushFront(vma);
+
+            RET_UNEXPECTED_IF(!new_node, MemError::OutOfMemory);
+            vma_guard.dismiss();
+            return {};
         }
     }
 
-    auto node = area_list_.PushFront(vma);
-    if (!node) {
-        KDelete(vma);
-        return unexpected(MemError::OutOfMemory);
-    }
+    RET_UNEXPECTED_IF(!area_list_.PushBack(vma), MemError::OutOfMemory);
+    vma_guard.dismiss();
 
     return {};
 }
@@ -173,4 +183,45 @@ bool AS::IsAddrInArea(const VMemArea *vma, VPtr<void> ptr)
     const auto vma_e = vma_s + vma->GetSize();
     const auto addr  = reinterpret_cast<uptr>(ptr);
     return vma_s <= addr && addr < vma_e;
+}
+
+expected<GapInfo, MemError> AS::FindGap(size_t size, VPtr<void> range_start, VPtr<void> range_end)
+{
+    std::lock_guard guard(area_list_lock_);
+
+    uptr search_start = range_start ? PtrToUptr(range_start) : 0;
+    uptr search_end   = range_end ? PtrToUptr(range_end) : UINTPTR_MAX;
+
+    // Sentinel value
+    uptr prev_end = search_start;
+
+    for (auto *vma : area_list_) {
+        uptr curr_start = PtrToUptr(vma->GetStart());
+        uptr curr_end   = curr_start + vma->GetSize();
+
+        // Find gaps only in the range of interest
+        if (curr_end <= search_start) {
+            continue;
+        }
+        if (curr_start >= search_end) {
+            break;
+        }
+
+        // Gap found
+        uptr gap_start = prev_end;
+        uptr gap_end   = curr_start;
+
+        if (gap_end > gap_start && (gap_end - gap_start) >= size) {
+            return GapInfo{UptrToPtr<void>(gap_start), size};
+        }
+
+        prev_end = curr_end;
+    }
+
+    // Final check: gap between last processed area and search_end
+    if (search_end > prev_end && (search_end - prev_end) >= size) {
+        return GapInfo{UptrToPtr<void>(prev_end), size};
+    }
+
+    return unexpected(MemError::NotFound);
 }

--- a/kernel/src/mem/virt/addr_space.hpp
+++ b/kernel/src/mem/virt/addr_space.hpp
@@ -42,6 +42,11 @@ struct TlbHint {
     size_t size;
 };
 
+struct GapInfo {
+    VPtr<void> start;
+    size_t size;
+};
+
 class AddressSpace
 {
     public:
@@ -74,6 +79,9 @@ class AddressSpace
 
     expected<TlbHint, MemError> RmArea(VPtr<void> ptr);
     expected<TlbHint, MemError> UpdateAreaFlags(VPtr<void> ptr, VirtualMemAreaFlags flags);
+    expected<GapInfo, MemError> FindGap(
+        size_t size, VPtr<void> start = nullptr, VPtr<void> end = nullptr
+    );
 
     // Helpers
     using AddrSpMutIt = data_structures::DoubleLinkedList<VMemArea *>::Iterator;
@@ -86,7 +94,8 @@ class AddressSpace
     PPtr<void> page_table_root_;
     bool owns_page_table_root_;
 
-    // List of pointers to VMA objects (we own these objects)
+    /// @brief Sorted list of pointers to VMA objects. We own these objects.
+    /// @note The list is sorted by the start address of the VMA objects.
     data_structures::DoubleLinkedList<VMemArea *> area_list_;
     hal::Spinlock area_list_lock_;
 

--- a/kernel/src/mem/virt/area.cpp
+++ b/kernel/src/mem/virt/area.cpp
@@ -17,7 +17,7 @@ namespace Mem
 static bool MapPage(AddressSpace &as, VPtr<void> vaddr, PPtr<void> paddr, VirtualMemAreaFlags flags)
 {
     auto &mmu      = MemoryModule::Get().GetMmu();
-    bool is_kernel = (Mem::PtrToUptr(vaddr) >= hal::kKernelVirtualAddressStart);
+    bool is_kernel = (Mem::PtrToUptr(vaddr) >= kKernelSpaceStart);
 
     hal::PageFlags page_flags{
         .Present        = true,
@@ -119,7 +119,7 @@ KernelSyncVMemArea::KernelSyncVMemArea()
     // Covers the entire upper half of the 64-bit address space
     // 0x8000000000000000 - 0xFFFFFFFFFFFFFFFF
     : VMemArea(
-          Mem::UptrToPtr<void>(kKernelSpaceStart), kKernelSpaceEnd - kKernelSpaceStart,
+          Mem::UptrToPtr<void>(kKernelSpaceStart), kKernelSpaceEndInclusive - kKernelSpaceStart,
           // Permissions are determined by the actual kernel page table entries being copied,
           // these flags are just placeholders for the VMA object.
           VirtualMemAreaFlags{.readable = true, .writable = true, .executable = true}

--- a/kernel/src/mem/virt/area.cpp
+++ b/kernel/src/mem/virt/area.cpp
@@ -2,12 +2,14 @@
 
 #include <string.h>
 #include <bits_ext.hpp>
-#include <hal/constants.hpp>
-#include <hal/panic.hpp>
-#include <mem/mmu/contexts.hpp>
-#include <mem/virt/addr_space.hpp>
-#include <modules/memory.hpp>
-#include <trace_framework.hpp>
+
+#include "constants.hpp"
+#include "hal/constants.hpp"
+#include "hal/panic.hpp"
+#include "mem/mmu/contexts.hpp"
+#include "mem/virt/addr_space.hpp"
+#include "modules/memory.hpp"
+#include "trace_framework.hpp"
 
 namespace Mem
 {
@@ -117,7 +119,7 @@ KernelSyncVMemArea::KernelSyncVMemArea()
     // Covers the entire upper half of the 64-bit address space
     // 0x8000000000000000 - 0xFFFFFFFFFFFFFFFF
     : VMemArea(
-          Mem::UptrToPtr<void>(kBitMaskLeft<u64, 1>), kBitMaskLeft<u64, 1> - 1,
+          Mem::UptrToPtr<void>(kKernelSpaceStart), kKernelSpaceEnd - kKernelSpaceStart,
           // Permissions are determined by the actual kernel page table entries being copied,
           // these flags are just placeholders for the VMA object.
           VirtualMemAreaFlags{.readable = true, .writable = true, .executable = true}

--- a/kernel/src/mem/virt/vmm.cpp
+++ b/kernel/src/mem/virt/vmm.cpp
@@ -4,6 +4,7 @@
 #include <macros.hpp>
 #include <template/scope_guard.hpp>
 
+#include "constants.hpp"
 #include "hal/constants.hpp"
 #include "mem/heap.hpp"
 #include "mem/mmu/contexts.hpp"
@@ -114,6 +115,57 @@ expected<void, MemError> Vmm::UpdateAreaFlags(
     tlb_->InvalidateRange(hint.start, hint.size);
 
     return {};
+}
+
+expected<VPtr<void>, MemError> Vmm::AllocAnonymous(
+    VPtr<AddressSpace> as, size_t size, VirtualMemAreaFlags flags, VPtr<void> range_start,
+    VPtr<void> range_end
+)
+{
+    auto gap_res = as->FindGap(size, range_start, range_end);
+    RET_UNEXPECTED_IF_ERR(gap_res);
+    auto gap = *gap_res;
+
+    auto vma_res = KNew<AnonymousVMemArea>(gap.start, gap.size, flags);
+    RET_UNEXPECTED_IF(!vma_res, MemError::OutOfMemory);
+    auto *vma = *vma_res;
+
+    auto add_res = as->AddArea(vma);
+    RET_UNEXPECTED_IF_ERR(add_res);
+
+    return gap.start;
+}
+
+expected<VPtr<void>, MemError> Vmm::AllocUserStack(VPtr<AddressSpace> as, size_t size)
+{
+    auto user_start = UptrToPtr<void>(kUserSpaceStart);
+    auto user_end   = UptrToPtr<void>(kUserSpaceEnd);
+
+    VirtualMemAreaFlags flags = {
+        .readable = true, .writable = true, .executable = false, .cache_disable = true
+    };
+
+    auto res = AllocAnonymous(as, size, flags, user_start, user_end);
+    RET_UNEXPECTED_IF_ERR(res);
+
+    VPtr<void> base = *res;
+
+    if constexpr (hal::kStackGrowsDown) {
+        return reinterpret_cast<VPtr<void>>(reinterpret_cast<uptr>(base) + size);
+    } else {
+        return base;
+    }
+}
+
+expected<VPtr<void>, MemError> Vmm::AllocKernelHeap(size_t size)
+{
+    auto kernel_start = UptrToPtr<void>(kKernelSpaceStart);
+
+    VirtualMemAreaFlags flags = {
+        .readable = true, .writable = true, .executable = false, .cache_disable = false
+    };
+
+    return AllocAnonymous(&kernel_as_, size, flags, kernel_start, nullptr);
 }
 
 }  // namespace Mem

--- a/kernel/src/mem/virt/vmm.cpp
+++ b/kernel/src/mem/virt/vmm.cpp
@@ -139,7 +139,7 @@ expected<VPtr<void>, MemError> Vmm::AllocAnonymous(
 expected<VPtr<void>, MemError> Vmm::AllocUserStack(VPtr<AddressSpace> as, size_t size)
 {
     auto user_start = UptrToPtr<void>(kUserSpaceStart);
-    auto user_end   = UptrToPtr<void>(kUserSpaceEnd);
+    auto user_end   = UptrToPtr<void>(kUserSpaceEndExclusive);
 
     VirtualMemAreaFlags flags = {
         .readable = true, .writable = true, .executable = false, .cache_disable = true

--- a/kernel/src/mem/virt/vmm.hpp
+++ b/kernel/src/mem/virt/vmm.hpp
@@ -53,6 +53,19 @@ class VirtualMemoryManager
         VPtr<AddressSpace> as, VPtr<void> region_start, VirtualMemAreaFlags vmaf
     );
 
+    // ------------------------------
+    // Allocation Helpers
+    // ------------------------------
+
+    expected<VPtr<void>, MemError> AllocAnonymous(
+        VPtr<AddressSpace> as, size_t size, VirtualMemAreaFlags flags,
+        VPtr<void> range_start = nullptr, VPtr<void> range_end = nullptr
+    );
+
+    expected<VPtr<void>, MemError> AllocUserStack(VPtr<AddressSpace> as, size_t size);
+
+    expected<VPtr<void>, MemError> AllocKernelHeap(size_t size);
+
     private:
     // ------------------------------
     // Class fields

--- a/kernel/src/scheduling/task_mgr.cpp
+++ b/kernel/src/scheduling/task_mgr.cpp
@@ -1,5 +1,6 @@
 #include <template/scope_guard.hpp>
 
+#include "constants.hpp"
 #include "modules/memory.hpp"
 #include "modules/scheduling.hpp"
 #include "scheduling/kworker.hpp"
@@ -42,9 +43,9 @@ std::expected<std::tuple<Pid, Tid>, Error> TaskMgr::SpawnProcess(
     bool dismiss = false;
 
     if (kernel_only) {
-        ASSERT_TRUE(hal::IsKernelSpace(reinterpret_cast<void *>(f)));
+        ASSERT_TRUE(IsKernelSpace(reinterpret_cast<void *>(f)));
     } else {
-        ASSERT_FALSE(hal::IsKernelSpace(reinterpret_cast<void *>(f)));
+        ASSERT_FALSE(IsKernelSpace(reinterpret_cast<void *>(f)));
     }
 
     // 1. Prepare internal structure for the process


### PR DESCRIPTION
## Problem
Userspace processes may need a stack. Currently there is no way to get it

## Solution
Added functionality that finds gaps of desired size in a desired range of the address space. 
The gaps are then used to insert Anonymous Vmem Areas there (as stack, or valloc, whatever you need)