### PR TITLE
Enable execution of user programs

### DIFF
--- a/kernel/arch/x86_64/src/cpu/gdt.hpp
+++ b/kernel/arch/x86_64/src/cpu/gdt.hpp
@@ -154,8 +154,8 @@ struct PACK Gdtr {
 struct alignas(16) PACK GDT {
     static constexpr u16 kKernelCodeSelector = 0x08;
     static constexpr u16 kKernelDataSelector = 0x10;
-    static constexpr u16 kUserCodeSelector   = 0x18;
-    static constexpr u16 kUserDataSelector   = 0x20;
+    static constexpr u16 kUserCodeSelector   = 0x1B;
+    static constexpr u16 kUserDataSelector   = 0x23;
     static constexpr u16 kTssSelector        = 0x28;
 
     GdtEntry<> null_entry;

--- a/kernel/arch/x86_64/src/include/scheduling.nasm
+++ b/kernel/arch/x86_64/src/include/scheduling.nasm
@@ -16,7 +16,7 @@ _ss_int_frame_offset equ _sp_int_frame_offset + 8
 
 _kernel_code_selector equ 0x08
 _kernel_data_selector equ 0x10
-_user_code_selector equ 0x18
-_user_data_selector equ 0x20
+_user_code_selector equ 0x1B
+_user_data_selector equ 0x23
 
 _jump_userspace_stack_space equ  5*8  ; sizeof(IsrStackFrame)

--- a/kernel/arch/x86_64/src/scheduling/scheduling.cpp
+++ b/kernel/arch/x86_64/src/scheduling/scheduling.cpp
@@ -1,6 +1,7 @@
 #include "modules/scheduling.hpp"
 
 #include <cpu/control_registers.hpp>
+#include <modules/memory.hpp>
 
 #include "cpu/utils.hpp"
 #include "hal/interrupt_params.hpp"
@@ -103,15 +104,18 @@ FAST_CALL u64 GetThreadsPageTable(Sched::Thread *thread)
     return reinterpret_cast<u64>(proc.value()->address_space->PageTableRoot());
 }
 
-FAST_CALL void SwapCr3IfNeeded(Sched::Thread *tcb)
+FAST_CALL void SwapAsIfNeeded(Sched::Thread *tcb)
 {
     ASSERT_NOT_NULL(tcb);
 
-    auto cr3 = cpu::GetCR<cpu::Cr3>();
+    const auto proc = SchedulingModule::Get().GetProcesses().GetProcess(tcb->owner);
+    ASSERT_TRUE(static_cast<bool>(proc), "Threads exists -> owner MUST exist");
 
-    auto next_cr3 = GetThreadsPageTable(tcb);
-    if (*reinterpret_cast<u64 *>(&cr3) != next_cr3) {
-        cpu::SetCR(*reinterpret_cast<cpu::Cr3 *>(&next_cr3));
+    auto &current_as = MemoryModule::Get().GetVmm().GetCurrentAddressSpace();
+    auto thread_as   = proc.value()->address_space;
+
+    if (&current_as != thread_as) {
+        MemoryModule::Get().GetVmm().SwitchAddrSpace(thread_as);
     }
 }
 
@@ -141,6 +145,10 @@ extern "C" void cdecl_JumpToUserSpaceEntry(void *addr, IsrStackFrame *frame)
 
     SetThreadGs(thread);
     __asm__ volatile("swapgs" ::: "memory");
+
+    const auto proc = SchedulingModule::Get().GetProcesses().GetProcess(thread->owner);
+    ASSERT_TRUE(static_cast<bool>(proc), "Threads exists -> owner MUST exist");
+    MemoryModule::Get().GetVmm().SwitchAddrSpace(proc.value()->address_space);
 }
 
 extern "C" void cdecl_ContextSwitchEntry(
@@ -161,7 +169,7 @@ extern "C" void cdecl_ContextSwitchEntry(
     SetTssRsp0(reinterpret_cast<u64>(thread->kernel_stack_bottom));
     SwapGsIfJumpingToUserspace(thread);
     LoadFpStateIfNeeded(thread);
-    SwapCr3IfNeeded(thread);
+    SwapAsIfNeeded(thread);
 }
 
 extern "C" void cdecl_ContextSwitchOnInterrupt(Sched::Thread *thread, void *rsp)
@@ -171,7 +179,7 @@ extern "C" void cdecl_ContextSwitchOnInterrupt(Sched::Thread *thread, void *rsp)
     SwapFsIfNeeded(current_tcb, thread);
     hardware::SetCurrentTCB(thread);
     SetTssRsp0(reinterpret_cast<u64>(thread->kernel_stack_bottom));
-    SwapCr3IfNeeded(thread);
+    SwapAsIfNeeded(thread);
 }
 
 // ===========================

--- a/kernel/src/init.cpp
+++ b/kernel/src/init.cpp
@@ -54,11 +54,12 @@ void KernelInit(const hal::RawBootArguments &raw_args)
     /* Fully Initialize ACPI subsystem */
     // HardwareModule::Get().GetACPIController().Init();
 
+    VfsModule::Init(args);
+
     SchedulingModule::Init();
     SchedulingModule::Get().GetTaskMgr().InitializeMultitasking();
 
     HardwareModule::Get().GetCoresController().BootUpAllCores();
 
-    VfsModule::Init(args);
     VideoModule::Init(args, MemoryModule::Get().GetHeap());
 }

--- a/kernel/src/mem/virt/area.cpp
+++ b/kernel/src/mem/virt/area.cpp
@@ -119,7 +119,8 @@ KernelSyncVMemArea::KernelSyncVMemArea()
     // Covers the entire upper half of the 64-bit address space
     // 0x8000000000000000 - 0xFFFFFFFFFFFFFFFF
     : VMemArea(
-          Mem::UptrToPtr<void>(kKernelSpaceStart), kKernelSpaceEndInclusive - kKernelSpaceStart,
+          Mem::UptrToPtr<void>(kKernelSpaceStart),
+          AlignDown(kKernelSpaceEndInclusive - kKernelSpaceStart, hal::kPageSizeBytes),
           // Permissions are determined by the actual kernel page table entries being copied,
           // these flags are just placeholders for the VMA object.
           VirtualMemAreaFlags{.readable = true, .writable = true, .executable = true}

--- a/kernel/src/mem/virt/vmm.cpp
+++ b/kernel/src/mem/virt/vmm.cpp
@@ -130,6 +130,8 @@ expected<VPtr<void>, MemError> Vmm::AllocAnonymous(
     RET_UNEXPECTED_IF(!vma_res, MemError::OutOfMemory);
     auto *vma = *vma_res;
 
+    UpdateAreaFlags(as, vma->GetStart(), flags);
+
     auto add_res = as->AddArea(vma);
     RET_UNEXPECTED_IF_ERR(add_res);
 

--- a/kernel/src/scheduling/task_mgr.cpp
+++ b/kernel/src/scheduling/task_mgr.cpp
@@ -4,7 +4,10 @@
 #include "modules/memory.hpp"
 #include "modules/scheduling.hpp"
 #include "scheduling/kworker.hpp"
+#include "sys/loader.hpp"
 #include "task_mgr.hpp"
+#include "vfs/path.hpp"
+
 #include "trace_framework.hpp"
 
 #include "hal/scheduling.hpp"
@@ -41,6 +44,10 @@ void TaskMgr::InitializeMultitasking()
     // Spawn trace dumper
     const auto result = SpawnKernelProcess("kworker-trace-dumper", {}, TraceDumperMain);
     R_ASSERT_TRUE(static_cast<bool>(result), "Failed to spawn trace dumper process...");
+
+    // Spawn hello world process
+    const auto res = ExecuteElf64("/bin/hello", {});
+    R_ASSERT_TRUE(static_cast<bool>(res), "Failed to spawn /bin/hello process...");
 }
 
 std::expected<Pid, Error> TaskMgr::SpawnEmptyProcess(const char *name, const ProcessFlags flags)
@@ -203,9 +210,37 @@ std::expected<std::tuple<Pid, Tid>, Error> TaskMgr::SpawnKernelProcess(
 
 std::expected<Pid, Error> TaskMgr::CloneProcess(Pid) { R_FAIL_ALWAYS("NOT IMPLEMENTED"); }
 
-std::expected<Tid, Error> TaskMgr::ExecuteElf64(Pid, const char *)
+std::expected<Tid, Error> TaskMgr::ExecuteElf64(Pid pid, const char *path)
 {
-    R_FAIL_ALWAYS("NOT IMPLEMENTED");
+    auto process = SchedulingModule::Get().GetProcesses().GetProcess(pid);
+    RET_UNEXPECTED_IF_ERR(process);
+
+    auto &as = process.value()->address_space;
+    ASSERT_NOT_NULL(as);
+
+    auto entry_res = System::ElfLoader::Load(vfs::Path(path), *as);
+    if (!entry_res) {
+        DEBUG_WARN_SCHEDULING(
+            "Failed to execute ELF64 for process %llu. Failed on ELF loading.", pid
+        );
+        return std::unexpected(Error::OutOfMemory);
+    }
+
+    const auto entry = reinterpret_cast<void (*)()>(entry_res.value());
+
+    auto thread = SpawnThread(pid, entry);
+    RET_UNEXPECTED_IF_ERR(thread);
+
+    HardwareModule::Get().GetInterrupts().BlockHardwareInterrupts();
+    SchedulingModule::Get().GetScheduler().AddReadyThread(thread.value());
+    HardwareModule::Get().GetInterrupts().EnableHardwareInterrupts();
+
+    DEBUG_INFO_SCHEDULING(
+        "Created userspace process with pid: %llu, name: %s and initial thread with tid: %llu", pid,
+        process.value()->name, thread.value()->tid
+    );
+
+    return thread.value()->tid;
 }
 
 std::expected<std::tuple<Pid, Tid>, Error> TaskMgr::ExecuteElf64(
@@ -213,19 +248,14 @@ std::expected<std::tuple<Pid, Tid>, Error> TaskMgr::ExecuteElf64(
 )
 {
     auto process = SpawnEmptyProcess(path, flags);
-    if (!process) {
-        return std::unexpected(process.error());
-    }
+    RET_UNEXPECTED_IF_ERR(process);
 
     template_lib::ScopeGuard process_guard([&] {
         const auto result = SchedulingModule::Get().GetProcesses().Free(process.value());
         ASSERT_TRUE(static_cast<bool>(result));
     });
-
     auto thread = ExecuteElf64(process.value(), path);
-    if (!thread) {
-        return std::unexpected(thread.error());
-    }
+    RET_UNEXPECTED_IF_ERR(thread);
 
     process_guard.dismiss();
     return std::make_tuple(process.value(), thread.value());

--- a/kernel/src/sys/loader.cpp
+++ b/kernel/src/sys/loader.cpp
@@ -109,6 +109,10 @@ expected<Mem::VPtr<void>, LoadError> ElfLoader::Load(const vfs::Path &path, Mem:
         }
     });
 
+    // Switch Address Space to load data
+    auto &prev_as = MemoryModule::Get().GetVmm().GetCurrentAddressSpace();
+    MemoryModule::Get().GetVmm().SwitchAddrSpace(&as);
+
     // 5. Load Segments
     TRACE_FREQ_INFO_GENERAL("Validating the ELF header");
     for (u16 i = 0; i < header.phnum; ++i) {
@@ -180,6 +184,9 @@ expected<Mem::VPtr<void>, LoadError> ElfLoader::Load(const vfs::Path &path, Mem:
             }
         }
     }
+
+    // Restore previous Address Space
+    MemoryModule::Get().GetVmm().SwitchAddrSpace(&prev_as);
 
     vma_cleanup_guard.dismiss();
     u64 entry_point = header.entry;

--- a/userspace/programs/hello_world/main.cpp
+++ b/userspace/programs/hello_world/main.cpp
@@ -7,29 +7,37 @@ void printf(const char *format, Args... args)
 {
     char buffer[256];
     snprintf(buffer, sizeof(buffer), format, args...);
-    __platform_write_console(buffer);
+    __platform_debug_write(buffer);
 }
 
 extern "C" int main()
 {
-    __platform_write_console(
+    printf(
         "\n----------------------------------\n"
         "Hello from User Space via Syscall!\n"
         "----------------------------------\n"
     );
 
-    printf("\nFormatting Test: %d + %d = %d\n\n", 2, 2, 4);
+    printf("Formatting Test: %d + %d = %d\n", 2, 2, 4);
 
     Timezone tz;
     __platform_get_timezone(&tz);
-    printf("Timezone offset (minutes): %d\n\n", tz.west_offset_minutes);
+    printf("Timezone offset (minutes): %d\n", tz.west_offset_minutes);
 
     u64 ticks = __platform_get_clock_ticks_in_second(kTimeUtc);
-    printf("Ticks per second (UTC): %llu\n\n", ticks);
+    printf("Ticks per second (UTC): %llu\n", ticks);
 
     TimeVal tv;
     __platform_get_clock_value(kTimeUtc, &tv, &tz);
-    printf("Current Timestamp: %llu\n\n", tv.seconds);
+    printf("Current Timestamp: %llu\n", tv.seconds);
+
+    while (true) {
+        static size_t kSpins = 1'000'000;
+        size_t counter       = 0;
+        for (size_t i = 0; i < kSpins; i++) {
+            ++counter;
+        }
+    }
 
     return 0;
 }


### PR DESCRIPTION

Adjust GDT selectors to correctly set RPL for user-mode segments.
Implement `ExecuteElf64` to load ELF binaries into a process's address space and spawn an initial thread.
Enhance address space switching logic to use the VMM's `SwitchAddrSpace` for better control during context switches and ELF loading.
Initialize VFS earlier to support ELF loading from the filesystem.
Launch a basic 'hello world' user program at boot to demonstrate functionality.